### PR TITLE
Use XML Format for Impex

### DIFF
--- a/config/common.cmake
+++ b/config/common.cmake
@@ -73,7 +73,6 @@ find_package(Qt5Widgets)
 find_package(Qt5Network)
 find_package(Qt5PrintSupport)
 find_package(Qt5Svg)
-find_package(Qt5Xml)
 
 # Instruct CMake to run moc automatically when needed.
 set(CMAKE_AUTOMOC ON)

--- a/config/common.cmake
+++ b/config/common.cmake
@@ -73,6 +73,7 @@ find_package(Qt5Widgets)
 find_package(Qt5Network)
 find_package(Qt5PrintSupport)
 find_package(Qt5Svg)
+find_package(Qt5Xml)
 
 # Instruct CMake to run moc automatically when needed.
 set(CMAKE_AUTOMOC ON)

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -6,6 +6,7 @@ project(graipe_core)
 set(SOURCES 
 	algorithm.cxx
 	colortables.cxx
+	globals.cxx
 	impex.cxx
 	logging.cxx
 	model.cxx
@@ -44,6 +45,7 @@ set(HEADERS
 	config.hxx
 	colortables.hxx
 	factories.hxx
+	globals.hxx
 	impex.hxx
 	logging.hxx
 	model.hxx

--- a/src/core/factories.hxx
+++ b/src/core/factories.hxx
@@ -150,6 +150,10 @@ typedef Factory<ViewControllerFactoryItem>      ViewControllerFactory;
 /** A Factory for Algorithms **/
 typedef Factory<AlgorithmFactoryItem> AlgorithmFactory;
 
+extern ModelFactory modelFactory;
+extern ViewControllerFactory viewControllerFactory;
+extern AlgorithmFactory algorithmFactory;
+
 }//end of namespace graipe
 
 /**

--- a/src/core/globals.cxx
+++ b/src/core/globals.cxx
@@ -33,33 +33,26 @@
 /*                                                                      */
 /************************************************************************/
 
-#include "core/module.hxx"
-#include "core/factories.hxx"
-
+#include "core/globals.hxx"
 
 /**
  * @file
- * @brief Implementation file for the Module class
+ * @brief Implementation file for the global vars
  *
  * @addtogroup core
  * @{
  */
 
 namespace graipe {
+    
+//Three global variables for the factories:
+ModelFactory modelFactory;
+ViewControllerFactory viewControllerFactory;
+AlgorithmFactory algorithmFactory;
 
-/**
- * Default constructor of the Module class
- */
-Module::Module()
-{
-}
- 
-/**
- * Default destructor of the Module class
- */
-Module::~Module()
-{
-}
+//And two more holding all currently available Models and ViewControllers:
+std::vector<Model*> models;
+std::vector<ViewController*> viewControllers;
 
 } //end of namespace graipe
 

--- a/src/core/globals.hxx
+++ b/src/core/globals.hxx
@@ -33,36 +33,36 @@
 /*                                                                      */
 /************************************************************************/
 
-#include "core/module.hxx"
-#include "core/factories.hxx"
+#ifndef GRAIPE_CORE_GLOBALS_HXX
+#define GRAIPE_CORE_GLOBALS_HXX
 
+#include "core/factories.hxx"
+#include "core/model.hxx"
+#include "core/viewcontroller.hxx"
+
+#include <vector>
 
 /**
  * @file
- * @brief Implementation file for the Module class
- *
+ * @brief This file holds all global data structures
  * @addtogroup core
  * @{
  */
-
+ 
 namespace graipe {
 
-/**
- * Default constructor of the Module class
- */
-Module::Module()
-{
-}
- 
-/**
- * Default destructor of the Module class
- */
-Module::~Module()
-{
-}
+//Three global variables for the factories:
+extern ModelFactory modelFactory;
+extern ViewControllerFactory viewControllerFactory;
+extern AlgorithmFactory algorithmFactory;
 
-} //end of namespace graipe
+//And two more holding all currently available Models and ViewControllers:
+extern std::vector<Model*> models;
+extern std::vector<ViewController*> viewControllers;
+}//end of namespace graipe
 
 /**
  * @}
  */
+
+#endif //GRAIPE_CORE_FACTORIES_HXX

--- a/src/core/globals.hxx
+++ b/src/core/globals.hxx
@@ -59,6 +59,7 @@ extern AlgorithmFactory algorithmFactory;
 //And two more holding all currently available Models and ViewControllers:
 extern std::vector<Model*> models;
 extern std::vector<ViewController*> viewControllers;
+
 }//end of namespace graipe
 
 /**

--- a/src/core/impex.cxx
+++ b/src/core/impex.cxx
@@ -216,7 +216,7 @@ ViewController* Impex::loadViewController(QXmlStreamReader & xmlReader, QGraphic
         for(Model* mod : models)
         {
             if(     mod
-                &&  mod->filename() == vc_modelID)
+                &&  mod->id() == vc_modelID)
             {
                 vc_model = mod;
                 break;

--- a/src/core/impex.cxx
+++ b/src/core/impex.cxx
@@ -69,17 +69,21 @@ bool Impex::load(const QString & filename, Serializable * object, bool compress)
             QIOCompressor compressor(&file);
             compressor.setStreamFormat(QIOCompressor::GzipFormat);
             
+            QXmlStreamReader xmlReader(&compressor);
+            
             if (compressor.open(QIODevice::ReadOnly))
             {
-                success = object->deserialize(compressor);
+                success = object->deserialize(xmlReader);
                 compressor.close();
             }
         }
         else
         {
+            QXmlStreamReader xmlReader(&file);
+            
             if(file.open(QIODevice::ReadOnly))
             {
-                success = object->deserialize(file);
+                success = object->deserialize(xmlReader);
                 file.close();
             }
         }

--- a/src/core/impex.cxx
+++ b/src/core/impex.cxx
@@ -142,7 +142,7 @@ Model* Impex::loadModel(QXmlStreamReader& xmlReader)
         //  If it was not found: Indicate error
         if(model == NULL)
         {
-            qWarning("Model type was not found in modelFactory.");
+            qWarning("Impex::loadModel: Model type was not found in modelFactory.");
             return NULL;
         }
         
@@ -152,14 +152,14 @@ Model* Impex::loadModel(QXmlStreamReader& xmlReader)
         }
         else
         {
-            qWarning("Deserialization of Model failed");
+            qWarning("Impex::loadModel: Deserialization of Model failed");
             delete model;
             return NULL;
         }
     }
     else
     {
-        qWarning("Could not find a single XML start element!");
+        qWarning("Impex::loadModel: Could not find a single XML start element!");
         return NULL;
     }
     return NULL;
@@ -225,7 +225,7 @@ ViewController* Impex::loadViewController(QXmlStreamReader & xmlReader, QGraphic
         //  If it was not found: Indicate error
         if(vc_model == NULL)
         {
-            qWarning("Model was not found among available ones.");
+            qWarning("Impex::loadViewController: Model was not found among available ones.");
             return NULL;
         }
         
@@ -241,7 +241,7 @@ ViewController* Impex::loadViewController(QXmlStreamReader & xmlReader, QGraphic
         //  If it was not found: Indicate error
         if(vc == NULL)
         {
-            qWarning("ViewController type was not found in the factory.");
+            qWarning("Impex::loadViewController: ViewController type was not found in the factory.");
             return NULL;
         }
         
@@ -252,14 +252,14 @@ ViewController* Impex::loadViewController(QXmlStreamReader & xmlReader, QGraphic
         }
         else
         {
-            qWarning("Deserialization of ViewController failed");
+            qWarning("Impex::loadViewController: Deserialization of ViewController failed");
             delete vc;
             return NULL;
         }
     }
     else
     {
-        qWarning("Could not find a single XML start element!");
+        qWarning("Impex::loadViewController: Could not find a single XML start element!");
         return NULL;
     }
     return NULL;

--- a/src/core/impex.cxx
+++ b/src/core/impex.cxx
@@ -210,9 +210,11 @@ bool Impex::save(Serializable * object, const QString & filename, bool compress)
 			QIOCompressor compressor(&file);
 			compressor.setStreamFormat(QIOCompressor::GzipFormat);
 		
+            QXmlStreamWriter xmlWriter(&compressor);
+            
 			if (compressor.open(QIODevice::WriteOnly))
 			{
-                object->serialize(compressor);
+                object->serialize(xmlWriter);
 				compressor.close();
 				
 				success = true;
@@ -220,7 +222,8 @@ bool Impex::save(Serializable * object, const QString & filename, bool compress)
 		}
 		else if(file.open(QIODevice::WriteOnly))
 		{
-            object->serialize(file);
+            QXmlStreamWriter xmlWriter(&file);
+            object->serialize(xmlWriter);
 			file.close();
 				
 			success = true;

--- a/src/core/impex.cxx
+++ b/src/core/impex.cxx
@@ -73,6 +73,7 @@ bool Impex::load(const QString & filename, Serializable * object, bool compress)
             
             if (compressor.open(QIODevice::ReadOnly))
             {
+                object->setFilename(filename);
                 success = object->deserialize(xmlReader);
                 compressor.close();
             }
@@ -83,6 +84,7 @@ bool Impex::load(const QString & filename, Serializable * object, bool compress)
             
             if(file.open(QIODevice::ReadOnly))
             {
+                object->setFilename(filename);
                 success = object->deserialize(xmlReader);
                 file.close();
             }

--- a/src/core/impex.hxx
+++ b/src/core/impex.hxx
@@ -42,6 +42,7 @@
 #include <map>
 
 #include <QString>
+#include <QXmlStreamWriter>
 
 /**
  * @file

--- a/src/core/impex.hxx
+++ b/src/core/impex.hxx
@@ -80,6 +80,15 @@ class GRAIPE_CORE_EXPORT Impex
 { 
 	public:
         /**
+         * Basic open procedure for compressed and uncompressed files.
+         *
+         * \param filename The filename of the stored object.
+         * \param openMode An openind mode, read/write-only etc.
+         * \return A valid QIODevice Pointer, if the opening was successful esle NULL.
+         */
+        static QIODevice* openFile(const QString & filename, QIODevice::OpenModeFlag openMode);
+    
+        /**
          * Basic import procedure for all types, which implement the serializable interface
          *
          * \param filename The filename of the stored object.

--- a/src/core/impex.hxx
+++ b/src/core/impex.hxx
@@ -86,16 +86,7 @@ class GRAIPE_CORE_EXPORT Impex
          * \return True, if the loading of the object was successful.
          */
         static bool load(const QString & filename, Serializable * rs_obj, bool compress=true);
-    
-        /**
-         * Reads the content of (maybe compressed) file to a QString.
-         * Mainly needed for views and their serialization.
-         *
-         * \param filename The filename to be read.
-         * \param compress If true, the file will be read using the GZip decompressor.
-         */
-        static QString readToString(const QString & filename, bool compress=true);
-    
+
         /**
          * Basic import procedure of a settings dictionary from a file.
          * A dictionary is defined by means of a mapping from QString keys
@@ -114,7 +105,7 @@ class GRAIPE_CORE_EXPORT Impex
          * \param contents The input QString.
          * \param separator The seaparator, which will be used to split the key/value pairs, default is ": "
          */
-         static std::map<QString,QString> dictFromString(const QString & contents, QString separator=": ");
+        static std::map<QString,QString> dictFromStream(QXmlStreamReader & xmlReader);
             
         /**
          * Standard exporter for everything, which implements the Serializable interface.

--- a/src/core/impex.hxx
+++ b/src/core/impex.hxx
@@ -36,8 +36,10 @@
 #ifndef GRAIPE_CORE_IMPEX_HXX
 #define GRAIPE_CORE_IMPEX_HXX
 
-#include "core/model.hxx"
 #include "core/config.hxx"
+
+#include "core/model.hxx"
+#include "core/viewcontroller.hxx"
 
 #include <map>
 
@@ -85,18 +87,28 @@ class GRAIPE_CORE_EXPORT Impex
          * \param compress If true, the file will be read using the GZip decompressor.
          * \return True, if the loading of the object was successful.
          */
-        static bool load(const QString & filename, Serializable * rs_obj, bool compress=true);
-
-        /**
-         * Basic import procedure of a settings dictionary from a file.
-         * A dictionary is defined by means of a mapping from QString keys
-         * to QString values.
-         *
-         * \param filename The filename to be read.
-         * \param compress If true, the file will be read using the GZip decompressor.
-         */
-        static std::map<QString,QString> dictFromFile(const QString & filename, bool compress=true);
+        static Model* loadModel(const QString & filename);
     
+        /**
+         * Basic import procedure for all types, which implement the serializable interface
+         *
+         * \param filename The filename of the stored object.
+         * \param object   The object, which shall be deserialized.
+         * \param compress If true, the file will be read using the GZip decompressor.
+         * \return True, if the loading of the object was successful.
+         */
+        static Model* loadModel(QXmlStreamReader & xmlReader);
+    
+        /**
+         * Basic import procedure for all types, which implement the serializable interface
+         *
+         * \param filename The filename of the stored object.
+         * \param object   The object, which shall be deserialized.
+         * \param compress If true, the file will be read using the GZip decompressor.
+         * \return True, if the loading of the object was successful.
+         */
+        static ViewController* loadViewController(const QString & filename, QGraphicsScene* scene);
+
         /**
          * Basic import procedure of a settings dictionary from a given QString
          * A dictionary is defined by means of a mapping from QString keys
@@ -105,7 +117,7 @@ class GRAIPE_CORE_EXPORT Impex
          * \param contents The input QString.
          * \param separator The seaparator, which will be used to split the key/value pairs, default is ": "
          */
-        static std::map<QString,QString> dictFromStream(QXmlStreamReader & xmlReader);
+        static ViewController* loadViewController(QXmlStreamReader & xmlReader, QGraphicsScene* scene);
             
         /**
          * Standard exporter for everything, which implements the Serializable interface.

--- a/src/core/logging.cxx
+++ b/src/core/logging.cxx
@@ -120,6 +120,7 @@ Logging::Logging()
         outputDirname = preferredDirname;
     }
     
+    
     //2. Assign class memebers
     m_file = new QFile(outputDirname+outputFilename);
     
@@ -127,6 +128,7 @@ Logging::Logging()
     {
         m_textStream = new QTextStream(m_file);
     }
+    qInfo() << "Starting log session";
 }
 
 /**
@@ -162,6 +164,7 @@ void Logging::logMessage(QtMsgType type, const QMessageLogContext &context, cons
             abort();
     }
     *m_textStream << txt << "\n";
+    m_textStream->flush();
 }
 
 }//end of namespace graipe

--- a/src/core/model.cxx
+++ b/src/core/model.cxx
@@ -36,8 +36,10 @@
 #include "core/model.hxx"
 #include "core/impex.hxx"
 #include "core/parameters.hxx"
+#include "core/globals.hxx"
 
 #include <cmath>
+#include <algorithm>
 
 #include <QtDebug>
 #include <QXmlStreamWriter>
@@ -83,6 +85,9 @@ Model::Model()
     m_parameters->addParameter("global_lr", m_global_lr);
     
     connect(m_parameters, SIGNAL(valueChanged()), this, SLOT(updateModel()));
+    
+    //Add to global Models list
+    models.push_back(this);
 }
 
 /**
@@ -115,6 +120,9 @@ Model::Model(const Model& model)
     m_parameters->addParameter("global_lr", m_global_lr);
     
     connect(m_parameters, SIGNAL(valueChanged()), this, SLOT(updateModel()));
+    
+    //Add to global Models list
+    models.push_back(this);
 }
 
 /**
@@ -124,6 +132,9 @@ Model::~Model()
 {
     //Delete the parameters
     delete m_parameters;
+    
+    //Remove from global models list
+    models.erase(std::remove(models.begin(), models.end(), this), models.end());
 }
 
 /**
@@ -574,15 +585,16 @@ bool Model::deserialize(QXmlStreamReader& xmlReader)
 {
     try
     {
-        if (xmlReader.readNextStartElement())
-        {
-            qDebug() << "Model::deserialize: readNextStartElement" << xmlReader.name();
+        //Assume, that the deserialized has already read the start node:
+        //if (xmlReader.readNextStartElement())
+        //{
+        //    qDebug() << "Model::deserialize: readNextStartElement" << xmlReader.name();
             
             if(xmlReader.name() == typeName())
             {
                 while(xmlReader.readNextStartElement())
                 {
-                    qDebug() << "Model::deserialize: readNextStartElement" << xmlReader.name();
+                    //qDebug() << "Model::deserialize: readNextStartElement" << xmlReader.name();
             
                     if(xmlReader.name() == "Header")
                     {
@@ -614,12 +626,15 @@ bool Model::deserialize(QXmlStreamReader& xmlReader)
                 }
                 return true;
             }
-        }
-        else
-        {
-            throw std::runtime_error("Did not find typeName() in XML tree");
-        }
-        throw std::runtime_error("Did not find any start element in XML tree");
+            else
+            {
+                throw std::runtime_error("Did not find typeName() in XML tree");
+            }
+        //}
+        //else
+        //{
+        //  throw std::runtime_error("Did not find any start element in XML tree");
+        //}
     }
     catch(std::runtime_error & e)
     {

--- a/src/core/model.cxx
+++ b/src/core/model.cxx
@@ -562,7 +562,12 @@ void Model::serialize(QXmlStreamWriter& xmlWriter) const
     xmlWriter.setAutoFormatting(true);
     xmlWriter.setAutoFormattingIndent(4);
     
-    xmlWriter.writeStartDocument();
+    bool fullFile = (xmlWriter.device()->pos() == 0);
+    
+    if (fullFile)
+    {
+        xmlWriter.writeStartDocument();
+     }
         xmlWriter.writeStartElement(typeName());
         xmlWriter.writeAttribute("ID", filename());
             xmlWriter.writeStartElement("Header");
@@ -571,8 +576,11 @@ void Model::serialize(QXmlStreamWriter& xmlWriter) const
             xmlWriter.writeStartElement("Content");
                 serialize_content(xmlWriter);
             xmlWriter.writeEndElement();
-        xmlWriter.writeEndElement();
-    xmlWriter.writeEndDocument();
+        xmlWriter.writeEndElement();    
+    if (fullFile)
+    {
+        xmlWriter.writeEndDocument();
+     }
 }
 
 /**

--- a/src/core/model.cxx
+++ b/src/core/model.cxx
@@ -62,7 +62,6 @@ Model::Model()
     Serializable(),
     m_name(new StringParameter("Name:", "", 20, NULL)),
     m_description(new LongStringParameter("Description:", "", 20, 6, NULL)),
-    m_save_filename(new LongStringParameter("Filename:", "", 20, 3, NULL)),
     m_ul(new PointParameter("Local upper-left (px.):", QPoint(0,0), QPoint(100000,100000), QPoint(0,0), NULL)),
     m_lr(new PointParameter("Local lower-right (px.):", QPoint(0,0),QPoint(100000,100000), QPoint(0,0), NULL)),
     m_global_ul(new PointFParameter("Global upper-left (deg.):", QPointF(-180,-90), QPointF(180,90), QPointF(0,0), NULL)),
@@ -74,9 +73,6 @@ Model::Model()
     
     m_parameters->addParameter("name", m_name);
     m_parameters->addParameter("descr", m_description);
-    
-                                                            //hidden==true
-    m_parameters->addParameter("filename", m_save_filename, true);
     
     m_parameters->addParameter("ul", m_ul);
     m_parameters->addParameter("lr", m_lr);
@@ -100,7 +96,6 @@ Model::Model(const Model& model)
     Serializable(),
     m_name(new StringParameter("Name:", model.name(),20, NULL)),
     m_description(new LongStringParameter("Description:", model.description(), 20, 6, NULL)),
-    m_save_filename(new LongStringParameter("Filename:", model.filename(), 20, 3, NULL)),
     m_ul(new PointParameter("Local upper-left:", QPoint(0,0), QPoint(100000,100000), QPoint(model.left(), model.top()), NULL)),
     m_lr(new PointParameter("Local lower-right:", QPoint(0,0),QPoint(100000,100000), QPoint(model.right(), model.bottom()), NULL)),
     m_global_ul(new PointFParameter("Global upper-left (deg.):", QPointF(-180,-90), QPointF(180,90), QPointF(model.globalLeft(), model.globalTop()), NULL)),
@@ -109,9 +104,6 @@ Model::Model(const Model& model)
 {
     m_parameters->addParameter("name", m_name);
     m_parameters->addParameter("descr", m_description);
-    
-                                                            //Hidden
-    m_parameters->addParameter("filename", m_save_filename, true);
     
     m_parameters->addParameter("ul", m_ul);
     m_parameters->addParameter("lr", m_lr);
@@ -200,32 +192,6 @@ void Model::setDescription(const QString & new_description)
         return;
     
     m_description->setValue(new_description);
-    updateModel();
-}
-
-/**
- * Const accessor for the model filename QString.
- *
- * \return The filename of the model.
- */
-QString Model::filename() const
-{
-	return m_save_filename->value();
-}
-
-/**
- * Set the model's filename to a new QString.
- *
- * \param new_filename The new filename of the model.
- */
-void Model::setFilename(const QString & new_filename)
-{
-    if(locked())
-        return;
-    
-    m_save_filename->setValue(new_filename);
-    m_filename = new_filename;
-    
     updateModel();
 }
 
@@ -520,7 +486,6 @@ void Model::copyMetadata(Model& other) const
 		
 		other.setName(name());
 		other.setDescription(description());
-		other.setFilename(filename());
 	}
 }
 
@@ -569,7 +534,7 @@ void Model::serialize(QXmlStreamWriter& xmlWriter) const
         xmlWriter.writeStartDocument();
      }
         xmlWriter.writeStartElement(typeName());
-        xmlWriter.writeAttribute("ID", filename());
+        xmlWriter.writeAttribute("ID", id());
             xmlWriter.writeStartElement("Header");
                 serialize_header(xmlWriter);
             xmlWriter.writeEndElement();

--- a/src/core/model.cxx
+++ b/src/core/model.cxx
@@ -514,13 +514,27 @@ QString Model::typeName() const
 }
 
 /**
- * This function serializes a complete Model to an output device.
- * To do so, it serializes header first, then the content, like this:
- *      serialize_header()
- *      [Content]
- *      serialize_content();
+ * This function serializes a complete Model to a xml stream.
+ * Writes the following XML code by default:
  *
- * \param out The output device for the serialization.
+ * <TYPENAME>
+ *     <Header>
+ *         HEADER
+ *     </Header>
+ *     <Content>
+ *         CONTENT
+ *     </Content>
+ * </TYPENAME>
+ *
+ * with TYPENAME = typeName(),
+ *        HEADER = serialize_header(), and
+ *       CONTENT = serialize_content().
+ *
+ * If the device, on which the writer writes, is not on the beginning (pos!=0),
+ * the writeStartDocument() and writeEndDocument() calls will be suppressed in
+ * order to allow multi-object files.
+ *
+ * \param xmlWriter The QXmlStreamWriter used for the serialization.
  */
 void Model::serialize(QXmlStreamWriter& xmlWriter) const
 {
@@ -618,11 +632,10 @@ bool Model::deserialize(QXmlStreamReader& xmlReader)
 }
 
 /**
- * This function serializes the header of a model like this:
- *      typeName()
- *      m_parameters->serialize()
+ * This function serializes the header of a model by means of a serialization of the
+ * models parameters (given as a ParameterGroup in m_parameters).
  *
- * \param out the output device.
+ * \param xmlWriter The QXmlStreamWriter, on which we write.
  */
 void Model::serialize_header(QXmlStreamWriter& xmlWriter) const
 {
@@ -653,9 +666,9 @@ bool Model::deserialize_header(QXmlStreamReader& xmlReader)
 
 /**
  * This function serializes the content of a model.
- * Has to be specialized, here always "none\n".
+ * Has to be specialized, here always "".
  *
- * \param out the output device.
+ * \param xmlWriter The QXmlStreamWriter, on which we write.
  */
 void Model::serialize_content(QXmlStreamWriter& xmlWriter) const
 {

--- a/src/core/model.cxx
+++ b/src/core/model.cxx
@@ -40,6 +40,7 @@
 #include <cmath>
 
 #include <QtDebug>
+#include <QXmlStreamWriter>
 
 /**
  * @file
@@ -544,7 +545,7 @@ QString Model::typeName() const
  */
 QString Model::magicID() const
 {
-    return  QString("[Graipe::") + typeName() + "]";
+    return  typeName();
 }
 
 /**
@@ -556,11 +557,21 @@ QString Model::magicID() const
  *
  * \param out The output device for the serialization.
  */
-void Model::serialize(QIODevice& out) const
+void Model::serialize(QXmlStreamWriter& xmlWriter) const
 {
-    serialize_header(out);
-    write_on_device("\n[Content]\n", out);
-    serialize_content(out);
+
+    
+    xmlWriter.setAutoFormatting(true);
+    xmlWriter.setAutoFormattingIndent(4);
+    
+    xmlWriter.writeStartDocument();
+        xmlWriter.writeStartElement(magicID());
+            m_parameters->serialize(xmlWriter);
+            xmlWriter.writeStartElement("Content");
+                serialize_content(xmlWriter);
+            xmlWriter.writeEndElement();
+        xmlWriter.writeEndElement();
+    xmlWriter.writeEndDocument();
 }
 
 /**
@@ -596,10 +607,8 @@ bool Model::deserialize(QIODevice& in)
  *
  * \param out the output device.
  */
-void Model::serialize_header(QIODevice& out) const
+void Model::serialize_header(QXmlStreamWriter& xmlWriter) const
 {
-	write_on_device(magicID() + "\n", out);
-    m_parameters->serialize(out);
 }
 
 /**
@@ -635,9 +644,8 @@ bool Model::deserialize_header(QIODevice& in)
  *
  * \param out the output device.
  */
-void Model::serialize_content(QIODevice& out) const
+void Model::serialize_content(QXmlStreamWriter& xmlWriter) const
 {
-    write_on_device("none\n", out);
 }
 
 /**

--- a/src/core/model.cxx
+++ b/src/core/model.cxx
@@ -508,7 +508,7 @@ void Model::copyData(Model& other) const
  *
  * \return "Model"
  */
-QString Model::typeName() const
+QString Model::typeName()
 {
 	return "Model";
 }
@@ -918,7 +918,7 @@ void RasteredModel::copyData(Model& other) const
  *
  * \return "RasteredModel"
  */
-QString RasteredModel::typeName() const
+QString RasteredModel::typeName()
 {
 	return "RasteredModel";
 }

--- a/src/core/model.cxx
+++ b/src/core/model.cxx
@@ -564,8 +564,12 @@ void Model::serialize(QXmlStreamWriter& xmlWriter) const
     
     xmlWriter.writeStartDocument();
         xmlWriter.writeStartElement(magicID());
-            serialize_header(xmlWriter);
-            serialize_content(xmlWriter);
+            xmlWriter.writeStartElement("Header");
+                serialize_header(xmlWriter);
+            xmlWriter.writeEndElement();
+            xmlWriter.writeStartElement("Content");
+                serialize_content(xmlWriter);
+            xmlWriter.writeEndElement();
         xmlWriter.writeEndElement();
     xmlWriter.writeEndDocument();
 }
@@ -627,9 +631,7 @@ bool Model::deserialize(QXmlStreamReader& xmlReader)
  */
 void Model::serialize_header(QXmlStreamWriter& xmlWriter) const
 {
-    xmlWriter.writeStartElement("Header");
-        m_parameters->serialize(xmlWriter);
-    xmlWriter.writeEndElement();
+    m_parameters->serialize(xmlWriter);
 }
 
 /**
@@ -662,9 +664,6 @@ bool Model::deserialize_header(QXmlStreamReader& xmlReader)
  */
 void Model::serialize_content(QXmlStreamWriter& xmlWriter) const
 {
-    xmlWriter.writeStartElement("Content");
-        serialize_content(xmlWriter);
-    xmlWriter.writeEndElement();
 }
 
 /**

--- a/src/core/model.cxx
+++ b/src/core/model.cxx
@@ -538,17 +538,6 @@ QString Model::typeName() const
 }
 
 /**
- * This function returns the automagically generated first header line for model
- * serialization.
- *
- * \return The first Header line, namely: "[Graipe::" + typeName() + "]"
- */
-QString Model::magicID() const
-{
-    return  typeName();
-}
-
-/**
  * This function serializes a complete Model to an output device.
  * To do so, it serializes header first, then the content, like this:
  *      serialize_header()
@@ -563,7 +552,7 @@ void Model::serialize(QXmlStreamWriter& xmlWriter) const
     xmlWriter.setAutoFormattingIndent(4);
     
     xmlWriter.writeStartDocument();
-        xmlWriter.writeStartElement(magicID());
+        xmlWriter.writeStartElement(typeName());
         xmlWriter.writeAttribute("ID", filename());
             xmlWriter.writeStartElement("Header");
                 serialize_header(xmlWriter);
@@ -589,7 +578,7 @@ bool Model::deserialize(QXmlStreamReader& xmlReader)
         {
             qDebug() << "Model::deserialize: readNextStartElement" << xmlReader.name();
             
-            if(xmlReader.name() == magicID())
+            if(xmlReader.name() == typeName())
             {
                 while(xmlReader.readNextStartElement())
                 {
@@ -628,13 +617,13 @@ bool Model::deserialize(QXmlStreamReader& xmlReader)
         }
         else
         {
-            throw std::runtime_error("Did not find magicID in XML tree");
+            throw std::runtime_error("Did not find typeName() in XML tree");
         }
         throw std::runtime_error("Did not find any start element in XML tree");
     }
     catch(std::runtime_error & e)
     {
-        qCritical() << "Parameter::deserialize failed! Was looking for magicID: " << magicID() << "Error: " << e.what();
+        qCritical() << "Parameter::deserialize failed! Was looking for typeName(): " << typeName() << "Error: " << e.what();
         return false;
     }
     return  false;
@@ -642,7 +631,7 @@ bool Model::deserialize(QXmlStreamReader& xmlReader)
 
 /**
  * This function serializes the header of a model like this:
- *      magicID()
+ *      typeName()
  *      m_parameters->serialize()
  *
  * \param out the output device.

--- a/src/core/model.cxx
+++ b/src/core/model.cxx
@@ -73,8 +73,8 @@ Model::Model()
     m_parameters->addParameter("name", m_name);
     m_parameters->addParameter("descr", m_description);
     
-    m_save_filename->hide(true);
-    m_parameters->addParameter("filename", m_save_filename);
+                                                            //hidden==true
+    m_parameters->addParameter("filename", m_save_filename, true);
     
     m_parameters->addParameter("ul", m_ul);
     m_parameters->addParameter("lr", m_lr);
@@ -105,8 +105,8 @@ Model::Model(const Model& model)
     m_parameters->addParameter("name", m_name);
     m_parameters->addParameter("descr", m_description);
     
-    m_save_filename->hide(true);
-    m_parameters->addParameter("filename", m_save_filename);
+                                                            //Hidden
+    m_parameters->addParameter("filename", m_save_filename, true);
     
     m_parameters->addParameter("ul", m_ul);
     m_parameters->addParameter("lr", m_lr);
@@ -564,6 +564,7 @@ void Model::serialize(QXmlStreamWriter& xmlWriter) const
     
     xmlWriter.writeStartDocument();
         xmlWriter.writeStartElement(magicID());
+        xmlWriter.writeAttribute("ID", filename());
             xmlWriter.writeStartElement("Header");
                 serialize_header(xmlWriter);
             xmlWriter.writeEndElement();
@@ -586,15 +587,32 @@ bool Model::deserialize(QXmlStreamReader& xmlReader)
     {
         if (xmlReader.readNextStartElement())
         {
+            qDebug() << "Model::deserialize: readNextStartElement" << xmlReader.name();
+            
             if(xmlReader.name() == magicID())
             {
                 while(xmlReader.readNextStartElement())
                 {
+                    qDebug() << "Model::deserialize: readNextStartElement" << xmlReader.name();
+            
                     if(xmlReader.name() == "Header")
                     {
                          if(!deserialize_header(xmlReader))
                          {
                             return false;
+                        }
+                        //Read until </Header> comes....
+                        while(true)
+                        {
+                            if(!xmlReader.readNext())
+                            {
+                                return false;
+                            }
+                            
+                            if(xmlReader.isEndElement() && xmlReader.name() == "Header")
+                            {
+                                break;
+                            }
                         }
                     }
                     if(xmlReader.name() == "Content")

--- a/src/core/model.cxx
+++ b/src/core/model.cxx
@@ -546,7 +546,7 @@ void Model::serialize(QXmlStreamWriter& xmlWriter) const
     if (fullFile)
     {
         xmlWriter.writeStartDocument();
-     }
+    }
         xmlWriter.writeStartElement(typeName());
         xmlWriter.writeAttribute("ID", id());
             xmlWriter.writeStartElement("Header");
@@ -559,7 +559,7 @@ void Model::serialize(QXmlStreamWriter& xmlWriter) const
     if (fullFile)
     {
         xmlWriter.writeEndDocument();
-     }
+    }
 }
 
 /**
@@ -577,8 +577,11 @@ bool Model::deserialize(QXmlStreamReader& xmlReader)
         //{
         //    qDebug() << "Model::deserialize: readNextStartElement" << xmlReader.name();
             
-            if(xmlReader.name() == typeName())
+            if(     xmlReader.name() == typeName()
+                &&  xmlReader.attributes().hasAttribute("ID"))
             {
+                setID(xmlReader.attributes().value("ID").toString());
+                
                 while(xmlReader.readNextStartElement())
                 {
                     //qDebug() << "Model::deserialize: readNextStartElement" << xmlReader.name();
@@ -615,7 +618,7 @@ bool Model::deserialize(QXmlStreamReader& xmlReader)
             }
             else
             {
-                throw std::runtime_error("Did not find typeName() in XML tree");
+                throw std::runtime_error("Did not find typeName() or id() in XML tree");
             }
         //}
         //else

--- a/src/core/model.cxx
+++ b/src/core/model.cxx
@@ -508,7 +508,7 @@ void Model::copyData(Model& other) const
  *
  * \return "Model"
  */
-QString Model::typeName()
+QString Model::typeName() const
 {
 	return "Model";
 }
@@ -918,7 +918,7 @@ void RasteredModel::copyData(Model& other) const
  *
  * \return "RasteredModel"
  */
-QString RasteredModel::typeName()
+QString RasteredModel::typeName() const
 {
 	return "RasteredModel";
 }

--- a/src/core/model.hxx
+++ b/src/core/model.hxx
@@ -340,14 +340,6 @@ class GRAIPE_CORE_EXPORT Model
         virtual QString typeName() const;
     
         /**
-         * This function returns the automagically generated first header line for model
-         * serialization.
-         *
-         * \return The first Header line, namely: "[Graipe::" + typeName() + "]"
-         */
-        QString magicID() const;
-    
-        /**
          * This function serializes a complete Model to a QString.
          * To do so, it serializes header first, then the content, like this:
          *      serialize_header()
@@ -368,7 +360,7 @@ class GRAIPE_CORE_EXPORT Model
     
         /**
          * This function serializes the header of a model like this:
-         *      magicID()
+         *      typeName()
          *      m_parameters->serialize()
          *
          * \param out the output device.

--- a/src/core/model.hxx
+++ b/src/core/model.hxx
@@ -614,13 +614,17 @@ class GRAIPE_CORE_EXPORT ItemListModel
          */
         void serialize_content(QXmlStreamWriter& xmlWriter) const
         {
-//TODO!!!            write_on_device(T::headerCSV(), out);
-    /*
+            xmlWriter.writeTextElement("Legend", T::headerCSV()());
+    
+            int i=0;
             for(const item_type& item : m_data)
             {
-                write_on_device("\n" + item.toCSV(), out);
+                xmlWriter.writeStartElement("Item");
+                xmlWriter.writeAttribute("ID", QString::number(i++));
+                    xmlWriter.writeCharacters(item.toCSV());
+                xmlWriter.writeEndElement();
             }
-            */
+
         }
     
         /**
@@ -635,32 +639,30 @@ class GRAIPE_CORE_EXPORT ItemListModel
         {
             if (locked())
                 return false;
-//TODO:
-       /*     //Read in header line and then throw it away immideately
-            if(!in.atEnd())
-                in.readLine();
 
             //Clean up
             clear();
             updateModel();
-
+            
             //Read the entries
-            while(!in.atEnd())
+            while(xmlReader.readNextStartElement())
             {
-                QString line(in.readLine());
-                
-                if(!line.isEmpty() && !line.startsWith(";"))
+                if(xmlReader.name() == "Item")
                 {
                     item_type new_item;
-                    if (!new_item.fromCSV(line))
+                    QString text = xmlReader.readElementText();
+                    if (!new_item.fromCSV(text))
                      {
-                        qCritical() << typeName() << "::deserialize_content: Item could not be deserialized from: '" << line << "'";
+                        qCritical() << typeName() << "::deserialize_content: Item could not be deserialized from: '" << text << "'";
                         return false;
                     }
                     append(new_item);
                 }
+                else
+                {
+                    xmlReader.skipCurrentElement();
+                }
             }
-            */
             return true;
         }
     

--- a/src/core/model.hxx
+++ b/src/core/model.hxx
@@ -324,7 +324,7 @@ class GRAIPE_CORE_EXPORT Model
          *
          * \return "Model"
          */
-        virtual QString typeName() const;
+        static QString typeName();
     
         /**
          * This function serializes a complete Model to a xml stream.
@@ -498,7 +498,7 @@ class GRAIPE_CORE_EXPORT ItemListModel
          *
          * \return T::typeName() + "List"
          */
-        QString typeName() const
+        static QString typeName()
         {
             return T::typeName() + "List";
         }
@@ -767,7 +767,7 @@ class GRAIPE_CORE_EXPORT RasteredModel
          *
          * \return "RasteredModel"
          */
-        QString typeName() const;
+        static QString typeName();
     
     protected:
         /** The additional parameters of this model: **/

--- a/src/core/model.hxx
+++ b/src/core/model.hxx
@@ -327,13 +327,27 @@ class GRAIPE_CORE_EXPORT Model
         virtual QString typeName() const;
     
         /**
-         * This function serializes a complete Model to a QString.
-         * To do so, it serializes header first, then the content, like this:
-         *      serialize_header()
-         *      [Content]
-         *      serialize_content();
+         * This function serializes a complete Model to a xml stream.
+         * Writes the following XML code by default:
          *
-         * \param out The output device for the serialization.
+         * <TYPENAME>
+         *     <Header>
+         *         HEADER
+         *     </Header>
+         *     <Content>
+         *         CONTENT
+         *     </Content>
+         * </TYPENAME>
+         *
+         * with TYPENAME = typeName(),
+         *        HEADER = serialize_header(), and
+         *       CONTENT = serialize_content().
+         *
+         * If the device, on which the writer writes, is not on the beginning (pos!=0),
+         * the writeStartDocument() and writeEndDocument() calls will be suppressed in
+         * order to allow multi-object files.
+         *
+         * \param xmlWriter The QXmlStreamWriter used for the serialization.
          */
         void serialize(QXmlStreamWriter& xmlWriter) const;
     
@@ -346,11 +360,10 @@ class GRAIPE_CORE_EXPORT Model
         bool deserialize(QXmlStreamReader& xmlReader);
     
         /**
-         * This function serializes the header of a model like this:
-         *      typeName()
-         *      m_parameters->serialize()
+         * This function serializes the header of a model by means of a serialization of the
+         * models parameters (given as a ParameterGroup in m_parameters).
          *
-         * \param out the output device.
+         * \param xmlWriter The QXmlStreamWriter, where we write on.
          */
         virtual void serialize_header(QXmlStreamWriter& xmlWriter) const;
     
@@ -364,9 +377,9 @@ class GRAIPE_CORE_EXPORT Model
     
         /**
          * This function serializes the content of a model.
-         * Has to be specialized, here always "none\n".
+         * Has to be specialized, here always "".
          *
-         * \param out the output device.
+         * \param xmlWriter The QXmlStreamWriter, on which we write.
          */
         virtual void serialize_content(QXmlStreamWriter& xmlWriter) const;
     

--- a/src/core/model.hxx
+++ b/src/core/model.hxx
@@ -364,7 +364,7 @@ class GRAIPE_CORE_EXPORT Model
          * \param  in The input device.
          * \return True, if the Model could be restored,
          */
-        bool deserialize(QIODevice& in);
+        bool deserialize(QXmlStreamReader& xmlReader);
     
         /**
          * This function serializes the header of a model like this:
@@ -381,7 +381,7 @@ class GRAIPE_CORE_EXPORT Model
          * \param  in The input device.
          * \return True, if the Model's header could be restored,
          */
-        virtual bool deserialize_header(QIODevice& in);
+        virtual bool deserialize_header(QXmlStreamReader& xmlReader);
     
         /**
          * This function serializes the content of a model.
@@ -397,7 +397,7 @@ class GRAIPE_CORE_EXPORT Model
          * \param  in The input device.
          * \return True, if the Model's content could be restored,
          */
-        virtual bool deserialize_content(QIODevice& in);
+        virtual bool deserialize_content(QXmlStreamReader& xmlReader);
     
         /**
          * Models may be locked (to read only access), while algorithms are using them e.g.
@@ -631,12 +631,12 @@ class GRAIPE_CORE_EXPORT ItemListModel
          * \param in The input device, where we read from.
          ± \return true, if the complete content could be deserialized from the input device.
          */
-        bool deserialize_content(QIODevice& in)
+        bool deserialize_content(QXmlStreamReader& xmlReader)
         {
             if (locked())
                 return false;
-                
-            //Read in header line and then throw it away immideately
+//TODO:
+       /*     //Read in header line and then throw it away immideately
             if(!in.atEnd())
                 in.readLine();
 
@@ -660,6 +660,7 @@ class GRAIPE_CORE_EXPORT ItemListModel
                     append(new_item);
                 }
             }
+            */
             return true;
         }
     

--- a/src/core/model.hxx
+++ b/src/core/model.hxx
@@ -144,20 +144,7 @@ class GRAIPE_CORE_EXPORT Model
          * \param new_description The new description of the model.
          */
 		virtual void setDescription(const QString & new_description);
-	
-        /**
-         * Const accessor for the model filename QString.
-         *
-         * \return The filename of the model.
-         */
-		virtual QString filename() const;
-    
-        /**
-         * Set the model's filename to a new QString.
-         *
-         * \param new_filename The new filename of the model.
-         */
-		virtual void setFilename(const QString & new_filename);
+
     
 		/**
          * Const accessor for the left (x-coordinate) of a Model.
@@ -445,7 +432,6 @@ class GRAIPE_CORE_EXPORT Model
         //The parameters of this model:
         StringParameter	    * m_name;
         LongStringParameter	* m_description;
-        LongStringParameter	* m_save_filename;
         PointParameter	    * m_ul, * m_lr;
         PointFParameter	    * m_global_ul, * m_global_lr;
     

--- a/src/core/model.hxx
+++ b/src/core/model.hxx
@@ -324,7 +324,7 @@ class GRAIPE_CORE_EXPORT Model
          *
          * \return "Model"
          */
-        static QString typeName();
+        virtual QString typeName() const;
     
         /**
          * This function serializes a complete Model to a xml stream.
@@ -496,11 +496,12 @@ class GRAIPE_CORE_EXPORT ItemListModel
         /**
          * The type of this model (same for every instance oif same templates).
          *
-         * \return T::typeName() + "List"
+         * \return T::typeName() const + "List"
          */
-        static QString typeName()
+        virtual QString typeName() const
         {
-            return T::typeName() + "List";
+            T temp;
+            return temp.typeName() + "List";
         }
     
         /**
@@ -767,7 +768,7 @@ class GRAIPE_CORE_EXPORT RasteredModel
          *
          * \return "RasteredModel"
          */
-        static QString typeName();
+        virtual QString typeName() const;
     
     protected:
         /** The additional parameters of this model: **/

--- a/src/core/model.hxx
+++ b/src/core/model.hxx
@@ -44,6 +44,7 @@
 #include <QTransform>
 #include <QObject>
 #include <QtDebug>
+#include <QXmlStreamWriter>
 
 /**
  * @file
@@ -355,7 +356,7 @@ class GRAIPE_CORE_EXPORT Model
          *
          * \param out The output device for the serialization.
          */
-        void serialize(QIODevice& out) const;
+        void serialize(QXmlStreamWriter& xmlWriter) const;
     
         /**
          * This function deserializes the model by means of its header and content
@@ -372,7 +373,7 @@ class GRAIPE_CORE_EXPORT Model
          *
          * \param out the output device.
          */
-        virtual void serialize_header(QIODevice& out) const;
+        virtual void serialize_header(QXmlStreamWriter& xmlWriter) const;
     
         /**
          * This function deserializes the Model's header.
@@ -388,7 +389,7 @@ class GRAIPE_CORE_EXPORT Model
          *
          * \param out the output device.
          */
-        virtual void serialize_content(QIODevice& out) const;
+        virtual void serialize_content(QXmlStreamWriter& xmlWriter) const;
     
         /**
          * This function deserializes the Model's content.
@@ -611,14 +612,15 @@ class GRAIPE_CORE_EXPORT ItemListModel
          *
          * \param out The output device, where the serialization will take place.
          */
-        void serialize_content(QIODevice & out) const
+        void serialize_content(QXmlStreamWriter& xmlWriter) const
         {
-            write_on_device(T::headerCSV(), out);
-    
+//TODO!!!            write_on_device(T::headerCSV(), out);
+    /*
             for(const item_type& item : m_data)
             {
                 write_on_device("\n" + item.toCSV(), out);
             }
+            */
         }
     
         /**

--- a/src/core/parameters/boolparameter.cxx
+++ b/src/core/parameters/boolparameter.cxx
@@ -80,7 +80,7 @@ BoolParameter::~BoolParameter()
  *
  * \return "BoolParameter".
  */
-QString BoolParameter::typeName() const
+QString BoolParameter::typeName()
 {
 	return "BoolParameter";
 }

--- a/src/core/parameters/boolparameter.cxx
+++ b/src/core/parameters/boolparameter.cxx
@@ -121,9 +121,9 @@ QString BoolParameter::toString() const
 }
 
 /**
- * Deserialization of a parameter's state from an input device.
+ * Deserialization of a parameter's state from a string.
  *
- * \param in the input device.
+ * \param str The input QString.
  * \return True, if the deserialization was successful, else false.
  */
 bool BoolParameter::fromString(QString& str)

--- a/src/core/parameters/boolparameter.cxx
+++ b/src/core/parameters/boolparameter.cxx
@@ -118,7 +118,7 @@ void BoolParameter::setValue(bool value)
  *
  * \return The value of the parameter converted to an QString
  */
-QString BoolParameter::valueText() const
+QString BoolParameter::toString() const
 {
     return (value()?"true":"false");
 }
@@ -129,23 +129,16 @@ QString BoolParameter::valueText() const
  * \param in the input device.
  * \return True, if the deserialization was successful, else false.
  */
-bool BoolParameter::deserialize(QIODevice& in)
+bool BoolParameter::fromString(QString& str)
 {
-    if(!Parameter::deserialize(in))
+    if (str == "true" || str == "false")
     {
-        return false;
-    }
-    
-    QString content(in.readLine().trimmed());
-    
-    if (content == "true" || content == "false")
-    {
-        setValue(content == "true");
+        setValue(str == "true");
         return true;
     }
     else
     {
-        qDebug() << "BoolParameter deserialize: value has to be either 'true' or 'false' in file, but found: " << content;
+        qDebug() << "BoolParameter deserialize: value has to be either 'true' or 'false' in file, but found: " << str;
     }
     return false;
 }

--- a/src/core/parameters/boolparameter.cxx
+++ b/src/core/parameters/boolparameter.cxx
@@ -80,7 +80,7 @@ BoolParameter::~BoolParameter()
  *
  * \return "BoolParameter".
  */
-QString BoolParameter::typeName()
+QString BoolParameter::typeName() const
 {
 	return "BoolParameter";
 }

--- a/src/core/parameters/boolparameter.cxx
+++ b/src/core/parameters/boolparameter.cxx
@@ -111,10 +111,7 @@ void BoolParameter::setValue(bool value)
 }
 
 /**
- * The value converted to a QString. Please note, that this can vary from the 
- * serialize() result, which also returns a QString. This is due to the fact,
- * that serialize also may perform encoding of QStrings to avoid special chars
- * inside the QString
+ * The value converted to a QString. Either true or false.
  *
  * \return The value of the parameter converted to an QString
  */

--- a/src/core/parameters/boolparameter.cxx
+++ b/src/core/parameters/boolparameter.cxx
@@ -36,6 +36,8 @@
 #include "core/parameters/boolparameter.hxx"
 
 #include <QtDebug>
+#include <QXmlStreamReader>
+#include <QXmlStreamWriter>
 
 /**
  * @file
@@ -119,18 +121,6 @@ void BoolParameter::setValue(bool value)
 QString BoolParameter::valueText() const
 {
     return (value()?"true":"false");
-}
-
-/**
- * Serialization of the parameter's state to an output device.
- * Basically, just: "BoolParameter, " + valueText()
- *
- * \param out The output device on which we serialize the parameter's state.
- */
-void BoolParameter::serialize(QIODevice& out) const
-{
-    Parameter::serialize(out);
-    write_on_device(", " + valueText(), out);
 }
 
 /**

--- a/src/core/parameters/boolparameter.hxx
+++ b/src/core/parameters/boolparameter.hxx
@@ -109,7 +109,7 @@ class GRAIPE_CORE_EXPORT BoolParameter
          *
          * \return The value of the parameter converted to an QString
          */
-        QString valueText() const;
+        QString toString() const;
     
         /**
          * Deserialization of a parameter's state from an input device.
@@ -117,7 +117,7 @@ class GRAIPE_CORE_EXPORT BoolParameter
          * \param in the input device.
          * \return True, if the deserialization was successful, else false.
          */
-        bool deserialize(QIODevice& in);
+        bool fromString(QString& str);
     
         /**
          * This function indicates whether the value of a parameter is valid or not.

--- a/src/core/parameters/boolparameter.hxx
+++ b/src/core/parameters/boolparameter.hxx
@@ -102,10 +102,7 @@ class GRAIPE_CORE_EXPORT BoolParameter
         void setValue(bool value);
             
         /**
-         * The value converted to a QString. Please note, that this can vary from the 
-         * serialize() result, which also returns a QString. This is due to the fact,
-         * that serialize also may perform encoding of QStrings to avoid special chars
-         * inside the QString
+         * The value converted to a QString. Either true or false.
          *
          * \return The value of the parameter converted to an QString
          */

--- a/src/core/parameters/boolparameter.hxx
+++ b/src/core/parameters/boolparameter.hxx
@@ -109,9 +109,9 @@ class GRAIPE_CORE_EXPORT BoolParameter
         QString toString() const;
     
         /**
-         * Deserialization of a parameter's state from an input device.
+         * Deserialization of a parameter's state from a string.
          *
-         * \param in the input device.
+         * \param str The input QString.
          * \return True, if the deserialization was successful, else false.
          */
         bool fromString(QString& str);

--- a/src/core/parameters/boolparameter.hxx
+++ b/src/core/parameters/boolparameter.hxx
@@ -110,14 +110,6 @@ class GRAIPE_CORE_EXPORT BoolParameter
          * \return The value of the parameter converted to an QString
          */
         QString valueText() const;
-            
-        /**
-         * Serialization of the parameter's state to an output device.
-         * Basically, just: "BoolParameter, " + valueText()
-         *
-         * \param out The output device on which we serialize the parameter's state.
-         */
-        void serialize(QIODevice& out) const;
     
         /**
          * Deserialization of a parameter's state from an input device.

--- a/src/core/parameters/boolparameter.hxx
+++ b/src/core/parameters/boolparameter.hxx
@@ -85,7 +85,7 @@ class GRAIPE_CORE_EXPORT BoolParameter
          *
          * \return "BoolParameter".
          */
-        static QString typeName();
+        virtual QString typeName() const;
     
         /** 
          * The current value of this parameter in the correct, most special type

--- a/src/core/parameters/boolparameter.hxx
+++ b/src/core/parameters/boolparameter.hxx
@@ -85,7 +85,7 @@ class GRAIPE_CORE_EXPORT BoolParameter
          *
          * \return "BoolParameter".
          */
-        virtual QString typeName() const;
+        static QString typeName();
     
         /** 
          * The current value of this parameter in the correct, most special type

--- a/src/core/parameters/colorparameter.cxx
+++ b/src/core/parameters/colorparameter.cxx
@@ -80,7 +80,7 @@ ColorParameter::~ColorParameter()
  *
  * \return "ColorParameter".
  */
-QString ColorParameter::typeName()
+QString ColorParameter::typeName() const
 {
     return "ColorParameter";
 }

--- a/src/core/parameters/colorparameter.cxx
+++ b/src/core/parameters/colorparameter.cxx
@@ -62,11 +62,8 @@ namespace graipe {
 ColorParameter::ColorParameter(const QString& name, QColor value, Parameter* parent, bool invert_parent)
 :	Parameter(name, parent, invert_parent),
     m_value(value),
-    m_delegate(new QPushButton(""))
+    m_delegate(NULL)
 {
-    setValue(value);
-    
-    initConnections();
 }
 
 /**
@@ -105,12 +102,17 @@ const QColor& ColorParameter::value() const
  */
 void ColorParameter::setValue(const QColor& value)
 {
-    QPixmap p(32, 32);
-    p.fill(value);
-    m_delegate->setIcon(QIcon(p));
-    
     m_value = value;
-    Parameter::updateValue();
+    
+    if(m_delegate!=NULL)
+    {
+        QPixmap p(32, 32);
+        p.fill(value);
+        m_delegate->setIcon(QIcon(p));
+        m_delegate->setText(toString());
+    
+        Parameter::updateValue();
+    }
 }
 
 /**
@@ -230,7 +232,7 @@ QWidget*  ColorParameter::delegate()
 {
     if (m_delegate == NULL)
     {
-        m_delegate = new QPushButton("");
+        m_delegate = new QPushButton(toString());
         
         QPixmap p(32, 32);
         p.fill(value());
@@ -250,11 +252,15 @@ QWidget*  ColorParameter::delegate()
  */
 void ColorParameter::updateValue()
 {
-    QColor col = QColorDialog::getColor(m_value, m_delegate, name());
-        
-    if(col.isValid())
+    //Should not happen - otherwise, better safe than sorry:
+    if(m_delegate != NULL)
     {
-       setValue(col);
+        QColor col = QColorDialog::getColor(m_value, m_delegate, name());
+        
+        if(col.isValid())
+        {
+            setValue(col);
+        }
     }
 }
 

--- a/src/core/parameters/colorparameter.cxx
+++ b/src/core/parameters/colorparameter.cxx
@@ -239,6 +239,7 @@ QWidget*  ColorParameter::delegate()
         connect(m_delegate, SIGNAL(clicked()), this, SLOT(updateValue()));
         Parameter::initConnections();
     }
+    
     return m_delegate;
 }
 

--- a/src/core/parameters/colorparameter.cxx
+++ b/src/core/parameters/colorparameter.cxx
@@ -80,7 +80,7 @@ ColorParameter::~ColorParameter()
  *
  * \return "ColorParameter".
  */
-QString ColorParameter::typeName() const
+QString ColorParameter::typeName()
 {
     return "ColorParameter";
 }

--- a/src/core/parameters/colorparameter.cxx
+++ b/src/core/parameters/colorparameter.cxx
@@ -136,7 +136,7 @@ void ColorParameter::serialize(QXmlStreamWriter& xmlWriter) const
 {
     xmlWriter.setAutoFormatting(true);
     
-    xmlWriter.writeStartElement(magicID());
+    xmlWriter.writeStartElement(typeName());
         xmlWriter.writeTextElement("Name", name());
         xmlWriter.writeStartElement("Color");
         xmlWriter.writeAttribute("Type", "RGB");
@@ -159,7 +159,7 @@ bool ColorParameter::deserialize(QXmlStreamReader& xmlReader)
     {
         if (xmlReader.readNextStartElement())
         {
-            if(xmlReader.name() == magicID())
+            if(xmlReader.name() == typeName())
             {
                 while(xmlReader.readNextStartElement())
                 {
@@ -197,13 +197,13 @@ bool ColorParameter::deserialize(QXmlStreamReader& xmlReader)
         }
         else
         {
-            throw std::runtime_error("Did not find magicID in XML tree");
+            throw std::runtime_error("Did not find typeName() in XML tree");
         }
         throw std::runtime_error("Did not find any start element in XML tree");
     }
     catch(std::runtime_error & e)
     {
-        qCritical() << "Parameter::deserialize failed! Was looking for magicID: " << magicID() << "Error: " << e.what();
+        qCritical() << "Parameter::deserialize failed! Was looking for typeName(): " << typeName() << "Error: " << e.what();
         return false;
     }
 }

--- a/src/core/parameters/colorparameter.cxx
+++ b/src/core/parameters/colorparameter.cxx
@@ -36,6 +36,7 @@
 #include "core/parameters/colorparameter.hxx"
 
 #include <QtDebug>
+#include <QXmlStreamWriter>
 #include <QObject>
 
 /**
@@ -131,10 +132,15 @@ QString  ColorParameter::valueText() const
  *
  * \param out The output device on which we serialize the parameter's state.
  */
-void ColorParameter::serialize(QIODevice& out) const
+void ColorParameter::serialize(QXmlStreamWriter& xmlWriter) const
 {
-    Parameter::serialize(out);
-    write_on_device(", " + QString("%1").arg(value().rgba()), out);
+    
+    xmlWriter.setAutoFormatting(true);
+    
+    xmlWriter.writeStartElement(magicID());
+    xmlWriter.writeTextElement("Name", name());
+    xmlWriter.writeTextElement("Value", QString("%1").arg(value().rgba()));
+    xmlWriter.writeEndElement();
 }
 
 /**

--- a/src/core/parameters/colorparameter.cxx
+++ b/src/core/parameters/colorparameter.cxx
@@ -127,9 +127,9 @@ QString  ColorParameter::toString() const
 }
 
 /**
- * Deserialization of a parameter's state from an input device.
+ * Deserialization of a parameter's state from a string.
  *
- * \param in the input device.
+ * \param str The input QString.
  * \return True, if the deserialization was successful, else false.
  */
 bool ColorParameter::fromString(QString & str)

--- a/src/core/parameters/colorparameter.hxx
+++ b/src/core/parameters/colorparameter.hxx
@@ -111,9 +111,9 @@ class GRAIPE_CORE_EXPORT ColorParameter
         QString toString() const;
     
         /**
-         * Deserialization of a parameter's state from an input device.
+         * Deserialization of a parameter's state from a string.
          *
-         * \param in the input device.
+         * \param str The input QString.
          * \return True, if the deserialization was successful, else false.
          */
         bool fromString(QString & str);

--- a/src/core/parameters/colorparameter.hxx
+++ b/src/core/parameters/colorparameter.hxx
@@ -119,7 +119,7 @@ class GRAIPE_CORE_EXPORT ColorParameter
          *
          * \param out The output device on which we serialize the parameter's state.
          */
-        void serialize(QIODevice& out) const;
+        void serialize(QXmlStreamWriter& xmlWriter) const;
     
         /**
          * Deserialization of a parameter's state from an input device.

--- a/src/core/parameters/colorparameter.hxx
+++ b/src/core/parameters/colorparameter.hxx
@@ -87,7 +87,7 @@ class GRAIPE_CORE_EXPORT ColorParameter
          *
          * \return "ColorParameter".
          */
-        virtual QString typeName() const;
+        static QString typeName();
         
         /** 
          * The current value of this parameter in the correct, most special type.

--- a/src/core/parameters/colorparameter.hxx
+++ b/src/core/parameters/colorparameter.hxx
@@ -104,22 +104,11 @@ class GRAIPE_CORE_EXPORT ColorParameter
         void setValue(const QColor& value);
             
         /**
-         * The value converted to a QString. Please note, that this can vary from the 
-         * serialize() result, which also returns a QString. This is due to the fact,
-         * that serialize also may perform encoding of QStrings to avoid special chars
-         * inside the QString.
+         * The value converted to a QString. This denotes the name of the color.
          *
          * \return The value of the parameter converted to an QString.
          */
         QString toString() const;
-            
-        /**
-         * Serialization of the parameter's state to an output device.
-         * Basically, just: "ColorParameter, " + value().rgba()
-         *
-         * \param out The output device on which we serialize the parameter's state.
-         */
-        void serialize(QXmlStreamWriter& xmlWriter) const;
     
         /**
          * Deserialization of a parameter's state from an input device.
@@ -127,7 +116,7 @@ class GRAIPE_CORE_EXPORT ColorParameter
          * \param in the input device.
          * \return True, if the deserialization was successful, else false.
          */
-        bool deserialize(QXmlStreamReader& xmlReader);
+        bool fromString(QString & str);
 
         /**
          * This function indicates whether the value of a parameter is valid or not.

--- a/src/core/parameters/colorparameter.hxx
+++ b/src/core/parameters/colorparameter.hxx
@@ -111,7 +111,7 @@ class GRAIPE_CORE_EXPORT ColorParameter
          *
          * \return The value of the parameter converted to an QString.
          */
-        QString valueText() const;
+        QString toString() const;
             
         /**
          * Serialization of the parameter's state to an output device.
@@ -127,7 +127,7 @@ class GRAIPE_CORE_EXPORT ColorParameter
          * \param in the input device.
          * \return True, if the deserialization was successful, else false.
          */
-        bool deserialize(QIODevice& in);
+        bool deserialize(QXmlStreamReader& xmlReader);
 
         /**
          * This function indicates whether the value of a parameter is valid or not.

--- a/src/core/parameters/colorparameter.hxx
+++ b/src/core/parameters/colorparameter.hxx
@@ -87,7 +87,7 @@ class GRAIPE_CORE_EXPORT ColorParameter
          *
          * \return "ColorParameter".
          */
-        static QString typeName();
+        virtual QString typeName() const;
         
         /** 
          * The current value of this parameter in the correct, most special type.

--- a/src/core/parameters/colortableparameter.cxx
+++ b/src/core/parameters/colortableparameter.cxx
@@ -83,7 +83,7 @@ ColorTableParameter::~ColorTableParameter()
  *
  * \return "ColorTableParameter".
  */
-QString ColorTableParameter::typeName() const
+QString ColorTableParameter::typeName()
 {
     return "ColorTableParameter";
 }

--- a/src/core/parameters/colortableparameter.cxx
+++ b/src/core/parameters/colortableparameter.cxx
@@ -83,7 +83,7 @@ ColorTableParameter::~ColorTableParameter()
  *
  * \return "ColorTableParameter".
  */
-QString ColorTableParameter::typeName()
+QString ColorTableParameter::typeName() const
 {
     return "ColorTableParameter";
 }

--- a/src/core/parameters/colortableparameter.cxx
+++ b/src/core/parameters/colortableparameter.cxx
@@ -238,18 +238,6 @@ QString  ColorTableParameter::valueText() const
 }
 
 /**
- * Serialization of the parameter's state to an output device.
- * Basically, just: "ColorTableParameter, " + valueText()
- *
- * \param out The output device on which we serialize the parameter's state.
- */
-void ColorTableParameter::serialize(QIODevice& out) const
-{
-    Parameter::serialize(out);
-    write_on_device(", " + valueText(), out);
-}
-
-/**
  * Deserialization of a parameter's state from an input device.
  *
  * \param in the input device.

--- a/src/core/parameters/colortableparameter.cxx
+++ b/src/core/parameters/colortableparameter.cxx
@@ -254,10 +254,22 @@ QString  ColorTableParameter::toString() const
 }
 
 /**
- * Serialization of the parameter's state to an output device.
- * Basically, just: "ColorParameter, " + value().rgba()
+ * Serialization of the parameter's state to a xml stream.
+ * Writes the following XML code by default:
+ * 
+ * <ColorTableParameter>
+ *     <Name>NAME</Name>
+ *     <Colors>COLORCOUNT</Colors>
+ *     <Color ID="0">#AARRGGBB</Color>
+ *     ...
+ *     <Color ID="COLORCOUNT-1">#AARRGGBB</Color>
+ * </ColorTableParameter>
  *
- * \param out The output device on which we serialize the parameter's state.
+ * with TYPENAME = typeName() and
+ *    COLORCOUNT = ct.size().
+ *
+ * \param xmlWriter The QXMLStreamWriter, which we use serialize the 
+ *                  parameter's type, name and value.
  */
 void ColorTableParameter::serialize(QXmlStreamWriter& xmlWriter) const
 {
@@ -280,9 +292,9 @@ void ColorTableParameter::serialize(QXmlStreamWriter& xmlWriter) const
 }
 
 /**
- * Deserialization of a parameter's state from an input device.
+ * Deserialization of a parameter's state from an xml file.
  *
- * \param in the input device.
+ * \param xmlReader The QXmlStreamReader, where we read from.
  * \return True, if the deserialization was successful, else false.
  */
 bool ColorTableParameter::deserialize(QXmlStreamReader& xmlReader)

--- a/src/core/parameters/colortableparameter.cxx
+++ b/src/core/parameters/colortableparameter.cxx
@@ -392,6 +392,7 @@ QWidget*  ColorTableParameter::delegate()
         connect(m_delegate, SIGNAL(currentIndexChanged(int)), this, SLOT(updateValue()));
         Parameter::initConnections();
     }
+    
     return m_delegate;
 }
 

--- a/src/core/parameters/colortableparameter.hxx
+++ b/src/core/parameters/colortableparameter.hxx
@@ -132,14 +132,6 @@ class GRAIPE_CORE_EXPORT ColorTableParameter
          * \return The value of the parameter converted to an QString.
          */
         QString valueText() const;
-            
-        /**
-         * Serialization of the parameter's state to an output device.
-         * Basically, just: "ColorTableParameter, " + valueText()
-         *
-         * \param out The output device on which we serialize the parameter's state.
-         */
-        void serialize(QIODevice& out) const;
     
         /**
          * Deserialization of a parameter's state from an input device.

--- a/src/core/parameters/colortableparameter.hxx
+++ b/src/core/parameters/colortableparameter.hxx
@@ -131,7 +131,15 @@ class GRAIPE_CORE_EXPORT ColorTableParameter
          *
          * \return The value of the parameter converted to an QString.
          */
-        QString valueText() const;
+        QString toString() const;
+    
+        /**
+         * Serialization of the parameter's state to an output device.
+         * Basically, just: "ColorParameter, " + value().rgba()
+         *
+         * \param out The output device on which we serialize the parameter's state.
+         */
+        void serialize(QXmlStreamWriter& xmlWriter) const;
     
         /**
          * Deserialization of a parameter's state from an input device.
@@ -139,7 +147,7 @@ class GRAIPE_CORE_EXPORT ColorTableParameter
          * \param in the input device.
          * \return True, if the deserialization was successful, else false.
          */
-        bool deserialize(QIODevice& in);
+        bool deserialize(QXmlStreamReader& xmlReader);
 
         /**
          * This function indicates whether the value of a parameter is valid or not.

--- a/src/core/parameters/colortableparameter.hxx
+++ b/src/core/parameters/colortableparameter.hxx
@@ -40,6 +40,7 @@
 #include "core/parameters/parameter.hxx"
 #include "core/parameters/parametergroup.hxx"
 
+#include <QPointer>
 #include <QComboBox>
 
 /**

--- a/src/core/parameters/colortableparameter.hxx
+++ b/src/core/parameters/colortableparameter.hxx
@@ -90,7 +90,7 @@ class GRAIPE_CORE_EXPORT ColorTableParameter
          *
          * \return "ColorTableParameter".
          */
-        virtual QString typeName() const;
+        static QString typeName();
         
         /** 
          * The current value of this parameter in the correct, most special type.

--- a/src/core/parameters/colortableparameter.hxx
+++ b/src/core/parameters/colortableparameter.hxx
@@ -135,17 +135,29 @@ class GRAIPE_CORE_EXPORT ColorTableParameter
         QString toString() const;
     
         /**
-         * Serialization of the parameter's state to an output device.
-         * Basically, just: "ColorParameter, " + value().rgba()
+         * Serialization of the parameter's state to a xml stream.
+         * Writes the following XML code by default:
+         * 
+         * <ColorTableParameter>
+         *     <Name>NAME</Name>
+         *     <Colors>COLORCOUNT</Colors>
+         *     <Color ID="0">#AARRGGBB</Color>
+         *     ...
+         *     <Color ID="COLORCOUNT-1">#AARRGGBB</Color>
+         * </ColorTableParameter>
          *
-         * \param out The output device on which we serialize the parameter's state.
+         * with TYPENAME = typeName() and
+         *    COLORCOUNT = ct.size().
+         *
+         * \param xmlWriter The QXMLStreamWriter, which we use serialize the 
+         *                  parameter's type, name and value.
          */
         void serialize(QXmlStreamWriter& xmlWriter) const;
     
         /**
-         * Deserialization of a parameter's state from an input device.
+         * Deserialization of a parameter's state from an xml file.
          *
-         * \param in the input device.
+         * \param xmlReader The QXmlStreamReader, where we read from.
          * \return True, if the deserialization was successful, else false.
          */
         bool deserialize(QXmlStreamReader& xmlReader);

--- a/src/core/parameters/colortableparameter.hxx
+++ b/src/core/parameters/colortableparameter.hxx
@@ -90,7 +90,7 @@ class GRAIPE_CORE_EXPORT ColorTableParameter
          *
          * \return "ColorTableParameter".
          */
-        static QString typeName();
+        virtual QString typeName() const;
         
         /** 
          * The current value of this parameter in the correct, most special type.

--- a/src/core/parameters/datetimeparameter.cxx
+++ b/src/core/parameters/datetimeparameter.cxx
@@ -78,7 +78,7 @@ DateTimeParameter::~DateTimeParameter()
  *
  * \return "DateTimeParameter".
  */
-QString  DateTimeParameter::typeName() const
+QString  DateTimeParameter::typeName()
 {
     return "DateTimeParameter";
 }

--- a/src/core/parameters/datetimeparameter.cxx
+++ b/src/core/parameters/datetimeparameter.cxx
@@ -122,18 +122,6 @@ QString DateTimeParameter::valueText() const
 }
 
 /**
- * Serialization of the parameter's state to an output device.
- * Basically, just: "DateTimeParameter, " + valueText()
- *
- * \param out The output device on which we serialize the parameter's state.
- */
-void DateTimeParameter::serialize(QIODevice& out) const
-{
-    Parameter::serialize(out);
-    write_on_device(", " + valueText(), out);
-}
-
-/**
  * Deserialization of a parameter's state from an input device.
  *
  * \param in the input device.

--- a/src/core/parameters/datetimeparameter.cxx
+++ b/src/core/parameters/datetimeparameter.cxx
@@ -78,7 +78,7 @@ DateTimeParameter::~DateTimeParameter()
  *
  * \return "DateTimeParameter".
  */
-QString  DateTimeParameter::typeName()
+QString  DateTimeParameter::typeName() const
 {
     return "DateTimeParameter";
 }

--- a/src/core/parameters/datetimeparameter.cxx
+++ b/src/core/parameters/datetimeparameter.cxx
@@ -60,7 +60,7 @@ namespace graipe {
 DateTimeParameter::DateTimeParameter(const QString& name, QDateTime value, Parameter* parent, bool invert_parent)
 :   Parameter(name, parent, invert_parent),
     m_value(value),
-    m_dteDelegate(NULL)
+    m_delegate(NULL)
 {
 }
 
@@ -69,8 +69,8 @@ DateTimeParameter::DateTimeParameter(const QString& name, QDateTime value, Param
  */
 DateTimeParameter::~DateTimeParameter()
 {
-    if(m_dteDelegate != NULL)
-        delete m_dteDelegate;
+    if(m_delegate != NULL)
+        delete m_delegate;
 }
 
 /**
@@ -102,8 +102,8 @@ void DateTimeParameter::setValue(const QDateTime& value)
 {
     m_value = value;
     
-    if (m_dteDelegate != NULL)
-        m_dteDelegate->setDateTime(value);
+    if (m_delegate != NULL)
+        m_delegate->setDateTime(value);
     
     Parameter::updateValue();
 }
@@ -163,18 +163,18 @@ bool DateTimeParameter::isValid() const
  */
 QWidget*  DateTimeParameter::delegate()
 {
-    if(m_dteDelegate == NULL)
+    if(m_delegate == NULL)
     {
-        m_dteDelegate = new QDateTimeEdit;
+        m_delegate = new QDateTimeEdit;
         
-        m_dteDelegate->setDisplayFormat("dd.MM.yyyy hh:mm:ss");
-        m_dteDelegate->setDateTime(value());
+        m_delegate->setDisplayFormat("dd.MM.yyyy hh:mm:ss");
+        m_delegate->setDateTime(value());
         
-        connect(m_dteDelegate, SIGNAL(dateTimeChanged(const QDateTime &)), this, SLOT(updateValue()));
+        connect(m_delegate, SIGNAL(dateTimeChanged(const QDateTime &)), this, SLOT(updateValue()));
         Parameter::initConnections();
     }
     
-    return m_dteDelegate;
+    return m_delegate;
 }
 
 /**
@@ -184,9 +184,9 @@ QWidget*  DateTimeParameter::delegate()
 void DateTimeParameter::updateValue()
 {
     //Should not happen - otherwise, better safe than sorry:
-    if(m_dteDelegate != NULL)
+    if(m_delegate != NULL)
     {
-        m_value = m_dteDelegate->dateTime();
+        m_value = m_delegate->dateTime();
         Parameter::updateValue();
     }
 }

--- a/src/core/parameters/datetimeparameter.cxx
+++ b/src/core/parameters/datetimeparameter.cxx
@@ -116,7 +116,7 @@ void DateTimeParameter::setValue(const QDateTime& value)
  *
  * \return The value of the parameter converted to an QString.
  */
-QString DateTimeParameter::valueText() const
+QString DateTimeParameter::toString() const
 {
     return value().toString("dd.MM.yyyy hh:mm:ss");
 }
@@ -127,16 +127,9 @@ QString DateTimeParameter::valueText() const
  * \param in the input device.
  * \return True, if the deserialization was successful, else false.
  */
-bool DateTimeParameter::deserialize(QIODevice& in)
+bool DateTimeParameter::fromString(QString& str)
 {
-    if(!Parameter::deserialize(in))
-    {
-        return false;
-    }
-    
-    QString content(in.readLine().trimmed());
-    
-    QDateTime dt = QDateTime::fromString(content,"dd.MM.yyyy hh:mm:ss");
+    QDateTime dt = QDateTime::fromString(str,"dd.MM.yyyy hh:mm:ss");
     
     if(dt.isValid())
     {
@@ -145,7 +138,7 @@ bool DateTimeParameter::deserialize(QIODevice& in)
     }
     else
     {
-        qDebug() << "DateTimeParameter deserialize: date could not be imported from file using format 'dd.MM.yyyy hh:mm:ss'. Was:" << content;
+        qDebug() << "DateTimeParameter deserialize: date could not be imported from file using format 'dd.MM.yyyy hh:mm:ss'. Was:" << str;
         return false;
     }
 }

--- a/src/core/parameters/datetimeparameter.cxx
+++ b/src/core/parameters/datetimeparameter.cxx
@@ -122,9 +122,9 @@ QString DateTimeParameter::toString() const
 }
 
 /**
- * Deserialization of a parameter's state from an input device.
+ * Deserialization of a parameter's state from a string.
  *
- * \param in the input device.
+ * \param str the input QString.
  * \return True, if the deserialization was successful, else false.
  */
 bool DateTimeParameter::fromString(QString& str)

--- a/src/core/parameters/datetimeparameter.cxx
+++ b/src/core/parameters/datetimeparameter.cxx
@@ -170,7 +170,7 @@ QWidget*  DateTimeParameter::delegate()
         m_dteDelegate->setDisplayFormat("dd.MM.yyyy hh:mm:ss");
         m_dteDelegate->setDateTime(value());
         
-        connect(m_dteDelegate, SIGNAL(clicked()), this, SLOT(updateValue()));
+        connect(m_dteDelegate, SIGNAL(dateTimeChanged(const QDateTime &)), this, SLOT(updateValue()));
         Parameter::initConnections();
     }
     

--- a/src/core/parameters/datetimeparameter.hxx
+++ b/src/core/parameters/datetimeparameter.hxx
@@ -105,11 +105,11 @@ class GRAIPE_CORE_EXPORT DateTimeParameter
          * The value converted to a QString. Please note, that this can vary from the 
          * serialize() result, which also returns a QString. This is due to the fact,
          * that serialize also may perform encoding of QStrings to avoid special chars
-         * inside the QString.
+         * inside the QString
          *
-         * \return The value of the parameter converted to an QString.
+         * \return The value of the parameter converted to an QString
          */
-        QString valueText() const;
+        QString toString() const;
     
         /**
          * Deserialization of a parameter's state from an input device.
@@ -117,7 +117,7 @@ class GRAIPE_CORE_EXPORT DateTimeParameter
          * \param in the input device.
          * \return True, if the deserialization was successful, else false.
          */
-        bool deserialize(QIODevice& in);
+        bool fromString(QString& str);
     
         /**
          * This function indicates whether the value of a parameter is valid or not.

--- a/src/core/parameters/datetimeparameter.hxx
+++ b/src/core/parameters/datetimeparameter.hxx
@@ -112,9 +112,9 @@ class GRAIPE_CORE_EXPORT DateTimeParameter
         QString toString() const;
     
         /**
-         * Deserialization of a parameter's state from an input device.
+         * Deserialization of a parameter's state from a string.
          *
-         * \param in the input device.
+         * \param str the input QString.
          * \return True, if the deserialization was successful, else false.
          */
         bool fromString(QString& str);

--- a/src/core/parameters/datetimeparameter.hxx
+++ b/src/core/parameters/datetimeparameter.hxx
@@ -85,7 +85,7 @@ class GRAIPE_CORE_EXPORT DateTimeParameter
          *
          * \return "DateTimeParameter".
          */
-        static QString typeName();
+        virtual QString typeName() const;
         
         /** 
          * The current value of this parameter in the correct, most special type.

--- a/src/core/parameters/datetimeparameter.hxx
+++ b/src/core/parameters/datetimeparameter.hxx
@@ -85,7 +85,7 @@ class GRAIPE_CORE_EXPORT DateTimeParameter
          *
          * \return "DateTimeParameter".
          */
-        virtual QString typeName() const;
+        static QString typeName();
         
         /** 
          * The current value of this parameter in the correct, most special type.

--- a/src/core/parameters/datetimeparameter.hxx
+++ b/src/core/parameters/datetimeparameter.hxx
@@ -148,7 +148,7 @@ class GRAIPE_CORE_EXPORT DateTimeParameter
         QDateTime m_value;
     
         /** The delegate widget **/
-        QPointer<QDateTimeEdit> m_dteDelegate;
+        QPointer<QDateTimeEdit> m_delegate;
 };
 
 } //end of namespace graipe

--- a/src/core/parameters/datetimeparameter.hxx
+++ b/src/core/parameters/datetimeparameter.hxx
@@ -110,14 +110,6 @@ class GRAIPE_CORE_EXPORT DateTimeParameter
          * \return The value of the parameter converted to an QString.
          */
         QString valueText() const;
-            
-        /**
-         * Serialization of the parameter's state to an output device.
-         * Basically, just: "DateTimeParameter, " + valueText()
-         *
-         * \param out The output device on which we serialize the parameter's state.
-         */
-        void serialize(QIODevice& out) const;
     
         /**
          * Deserialization of a parameter's state from an input device.

--- a/src/core/parameters/doubleparameter.cxx
+++ b/src/core/parameters/doubleparameter.cxx
@@ -82,7 +82,7 @@ DoubleParameter::~DoubleParameter()
  *
  * \return "DoubleParameter".
  */
-QString  DoubleParameter::typeName()
+QString  DoubleParameter::typeName() const
 {
 	return "DoubleParameter";
 }

--- a/src/core/parameters/doubleparameter.cxx
+++ b/src/core/parameters/doubleparameter.cxx
@@ -82,7 +82,7 @@ DoubleParameter::~DoubleParameter()
  *
  * \return "DoubleParameter".
  */
-QString  DoubleParameter::typeName() const
+QString  DoubleParameter::typeName()
 {
 	return "DoubleParameter";
 }

--- a/src/core/parameters/doubleparameter.cxx
+++ b/src/core/parameters/doubleparameter.cxx
@@ -185,18 +185,6 @@ QString DoubleParameter::valueText() const
 }
 
 /**
- * Serialization of the parameter's state to an output device.
- * Basically, just: "DoubleParameter, " + valueText()
- *
- * \param out The output device on which we serialize the parameter's state.
- */
-void DoubleParameter::serialize(QIODevice& out) const
-{
-    Parameter::serialize(out);
-    write_on_device(", " + valueText(), out);
-}
-
-/**
  * Deserialization of a parameter's state from an input device.
  *
  * \param in the input device.

--- a/src/core/parameters/doubleparameter.cxx
+++ b/src/core/parameters/doubleparameter.cxx
@@ -179,7 +179,7 @@ void DoubleParameter::setValue(double value)
  *
  * \return The value of the parameter converted to an QString.
  */
-QString DoubleParameter::valueText() const
+QString DoubleParameter::toString() const
 {
 	return QString::number(value(),'g', 10);
 }
@@ -190,25 +190,18 @@ QString DoubleParameter::valueText() const
  * \param in the input device.
  * \return True, if the deserialization was successful, else false.
  */
-bool DoubleParameter::deserialize(QIODevice& in)
+bool DoubleParameter::fromString(QString& str)
 {
-    if(!Parameter::deserialize(in))
-    {
-        return false;
-    }
-    
-    QString content(in.readLine().trimmed());
-
     try
     {
-        double val = content.toDouble();
+        double val = str.toDouble();
         setValue(val);
         
         return true;
     }
     catch (...)
     {
-        qCritical() << "DoubleParameter deserialize: value could not be imported from: '" << content << "'";
+        qCritical() << "DoubleParameter deserialize: value could not be imported from: '" << str << "'";
     }
     return false;
 }

--- a/src/core/parameters/doubleparameter.cxx
+++ b/src/core/parameters/doubleparameter.cxx
@@ -64,7 +64,7 @@ DoubleParameter::DoubleParameter(const QString& name, double low, double upp, do
     m_value(value),
     m_min_value(low),
     m_max_value(upp),
-    m_dsbDelegate(NULL)
+    m_delegate(NULL)
 {
 }
 
@@ -73,8 +73,8 @@ DoubleParameter::DoubleParameter(const QString& name, double low, double upp, do
  */
 DoubleParameter::~DoubleParameter()
 {
-    if(m_dsbDelegate == NULL)
-        delete m_dsbDelegate;
+    if(m_delegate == NULL)
+        delete m_delegate;
 }
 
 /**
@@ -94,7 +94,7 @@ QString  DoubleParameter::typeName() const
  */
 double DoubleParameter::lowerBound() const
 {
-    return m_min_value;//m_dsbDelegate->minimum();
+    return m_min_value;//m_delegate->minimum();
 }
 
 /**
@@ -106,8 +106,8 @@ void DoubleParameter::setLowerBound(double value)
 {
     m_min_value = value;
     
-    if(m_dsbDelegate != NULL)
-        m_dsbDelegate->setMinimum(value);
+    if(m_delegate != NULL)
+        m_delegate->setMinimum(value);
 }
 
 /**
@@ -117,7 +117,7 @@ void DoubleParameter::setLowerBound(double value)
  */
 double DoubleParameter::upperBound() const
 {
-    return m_max_value;//m_dsbDelegate->maximum();
+    return m_max_value;//m_delegate->maximum();
 }
 
 /**
@@ -129,8 +129,8 @@ void DoubleParameter::setUpperBound(double value)
 {
     m_max_value = value;
     
-    if(m_dsbDelegate != NULL)
-        m_dsbDelegate->setMaximum(value);
+    if(m_delegate != NULL)
+        m_delegate->setMaximum(value);
 }
 
 /**
@@ -152,7 +152,7 @@ void DoubleParameter::setRange(double min_value, double max_value)
  */
 double DoubleParameter::value() const
 {
-    return m_value;//m_dsbDelegate->value();
+    return m_value;//m_delegate->value();
 }
 
 /**
@@ -164,9 +164,9 @@ void DoubleParameter::setValue(double value)
 {
     m_value = value;
     
-    if(m_dsbDelegate != NULL)
+    if(m_delegate != NULL)
     {
-        m_dsbDelegate->setValue(value);
+        m_delegate->setValue(value);
         Parameter::updateValue();
     }
 }
@@ -226,18 +226,18 @@ bool DoubleParameter::isValid() const
  */
 QWidget*  DoubleParameter::delegate()
 {
-    if(m_dsbDelegate == NULL)
+    if(m_delegate == NULL)
     {
-        m_dsbDelegate = new QDoubleSpinBox;
+        m_delegate = new QDoubleSpinBox;
     
-        m_dsbDelegate->setDecimals(3);
-        m_dsbDelegate->setRange(lowerBound(),upperBound());
-        m_dsbDelegate->setValue(value());
+        m_delegate->setDecimals(3);
+        m_delegate->setRange(lowerBound(),upperBound());
+        m_delegate->setValue(value());
         
-        connect(m_dsbDelegate, SIGNAL(valueChanged(double)), this, SLOT(updateValue()));
+        connect(m_delegate, SIGNAL(valueChanged(double)), this, SLOT(updateValue()));
         Parameter::initConnections();
     }
-    return m_dsbDelegate;
+    return m_delegate;
 }
 
 /**
@@ -247,9 +247,9 @@ QWidget*  DoubleParameter::delegate()
 void DoubleParameter::updateValue()
 {
     //Should not happen - otherwise, better safe than sorry:
-    if(m_dsbDelegate != NULL)
+    if(m_delegate != NULL)
     {
-        m_value = m_dsbDelegate->value();
+        m_value = m_delegate->value();
         Parameter::updateValue();
     }
 }

--- a/src/core/parameters/doubleparameter.cxx
+++ b/src/core/parameters/doubleparameter.cxx
@@ -185,9 +185,9 @@ QString DoubleParameter::toString() const
 }
 
 /**
- * Deserialization of a parameter's state from an input device.
+ * Deserialization of a parameter's state from a string.
  *
- * \param in the input device.
+ * \param str the input QString.
  * \return True, if the deserialization was successful, else false.
  */
 bool DoubleParameter::fromString(QString& str)

--- a/src/core/parameters/doubleparameter.hxx
+++ b/src/core/parameters/doubleparameter.hxx
@@ -87,7 +87,7 @@ class GRAIPE_CORE_EXPORT DoubleParameter
          *
          * \return "DoubleParameter".
          */
-        virtual QString typeName() const;
+        static QString typeName();
         /**
          * The lowest possible value of this parameter.
          *

--- a/src/core/parameters/doubleparameter.hxx
+++ b/src/core/parameters/doubleparameter.hxx
@@ -149,9 +149,9 @@ class GRAIPE_CORE_EXPORT DoubleParameter
         QString toString() const;
     
         /**
-         * Deserialization of a parameter's state from an input device.
+         * Deserialization of a parameter's state from a string.
          *
-         * \param in the input device.
+         * \param str the input QString.
          * \return True, if the deserialization was successful, else false.
          */
         bool fromString(QString& str);

--- a/src/core/parameters/doubleparameter.hxx
+++ b/src/core/parameters/doubleparameter.hxx
@@ -147,14 +147,6 @@ class GRAIPE_CORE_EXPORT DoubleParameter
          * \return The value of the parameter converted to an QString.
          */
         QString valueText() const;
-            
-        /**
-         * Serialization of the parameter's state to an output device.
-         * Basically, just: "DoubleParameter, " + valueText()
-         *
-         * \param out The output device on which we serialize the parameter's state.
-         */
-        void serialize(QIODevice& out) const;
     
         /**
          * Deserialization of a parameter's state from an input device.

--- a/src/core/parameters/doubleparameter.hxx
+++ b/src/core/parameters/doubleparameter.hxx
@@ -137,16 +137,16 @@ class GRAIPE_CORE_EXPORT DoubleParameter
          * \param value The new value of this parameter.
          */
         void setValue(double value);
-    
+            
         /**
          * The value converted to a QString. Please note, that this can vary from the 
          * serialize() result, which also returns a QString. This is due to the fact,
          * that serialize also may perform encoding of QStrings to avoid special chars
-         * inside the QString.
+         * inside the QString
          *
-         * \return The value of the parameter converted to an QString.
+         * \return The value of the parameter converted to an QString
          */
-        QString valueText() const;
+        QString toString() const;
     
         /**
          * Deserialization of a parameter's state from an input device.
@@ -154,7 +154,7 @@ class GRAIPE_CORE_EXPORT DoubleParameter
          * \param in the input device.
          * \return True, if the deserialization was successful, else false.
          */
-        bool deserialize(QIODevice& in);
+        bool fromString(QString& str);
     
         /**
          * This function indicates whether the value of a parameter is valid or not.

--- a/src/core/parameters/doubleparameter.hxx
+++ b/src/core/parameters/doubleparameter.hxx
@@ -188,7 +188,7 @@ class GRAIPE_CORE_EXPORT DoubleParameter
         double m_min_value, m_max_value;
     
         /** The delegate widget **/
-        QPointer<QDoubleSpinBox> m_dsbDelegate;
+        QPointer<QDoubleSpinBox> m_delegate;
 };
 
 } //end of namespace graipe

--- a/src/core/parameters/doubleparameter.hxx
+++ b/src/core/parameters/doubleparameter.hxx
@@ -87,7 +87,7 @@ class GRAIPE_CORE_EXPORT DoubleParameter
          *
          * \return "DoubleParameter".
          */
-        static QString typeName();
+        virtual QString typeName() const;
         /**
          * The lowest possible value of this parameter.
          *

--- a/src/core/parameters/enumparameter.cxx
+++ b/src/core/parameters/enumparameter.cxx
@@ -81,7 +81,7 @@ EnumParameter::~EnumParameter()
  *
  * \return "EnumParameter".
  */
-QString  EnumParameter::typeName() const
+QString  EnumParameter::typeName()
 {
 	return "EnumParameter";
 }

--- a/src/core/parameters/enumparameter.cxx
+++ b/src/core/parameters/enumparameter.cxx
@@ -138,7 +138,7 @@ void EnumParameter::serialize(QXmlStreamWriter& xmlWriter) const
 {
     xmlWriter.setAutoFormatting(true);
     
-    xmlWriter.writeStartElement(magicID());
+    xmlWriter.writeStartElement(typeName());
     xmlWriter.writeTextElement("Name", name());
     xmlWriter.writeTextElement("Value", QString("%1").arg(value()));
     xmlWriter.writeEndElement();
@@ -156,7 +156,7 @@ bool EnumParameter::deserialize(QXmlStreamReader& xmlReader)
     {
         if(xmlReader.readNextStartElement())
         {
-            if(xmlReader.name() == magicID())
+            if(xmlReader.name() == typeName())
             {
                 while(xmlReader.readNextStartElement())
                 {
@@ -176,13 +176,13 @@ bool EnumParameter::deserialize(QXmlStreamReader& xmlReader)
         }
         else
         {
-            throw std::runtime_error("Did not find magicID in XML tree");
+            throw std::runtime_error("Did not find typeName() in XML tree");
         }
         throw std::runtime_error("Did not find any start element in XML tree");
     }
     catch(std::runtime_error & e)
     {
-        qCritical() << "EnumParameter::deserialize failed! Was looking for magicID: " << magicID() << "Error: " << e.what();
+        qCritical() << "EnumParameter::deserialize failed! Was looking for typeName(): " << typeName() << "Error: " << e.what();
         return false;
     }
 }

--- a/src/core/parameters/enumparameter.cxx
+++ b/src/core/parameters/enumparameter.cxx
@@ -81,7 +81,7 @@ EnumParameter::~EnumParameter()
  *
  * \return "EnumParameter".
  */
-QString  EnumParameter::typeName()
+QString  EnumParameter::typeName() const
 {
 	return "EnumParameter";
 }

--- a/src/core/parameters/enumparameter.cxx
+++ b/src/core/parameters/enumparameter.cxx
@@ -215,7 +215,7 @@ QWidget*  EnumParameter::delegate()
         }
         m_cmbDelegate->setCurrentIndex(m_value);
     
-        connect(m_cmbDelegate, SIGNAL(clicked()), this, SLOT(updateValue()));
+        connect(m_cmbDelegate, SIGNAL(currentIndexChanged(int)), this, SLOT(updateValue()));
         Parameter::initConnections();
     }
     return m_cmbDelegate;

--- a/src/core/parameters/enumparameter.cxx
+++ b/src/core/parameters/enumparameter.cxx
@@ -129,10 +129,20 @@ QString EnumParameter::toString() const
 }
 
 /**
- * Serialization of the parameter's state to an output device.
- * Basically, just: "EnumParameter: " + Index of enum
+ * Serialization of the parameter's state to a xml stream.
+ * Writes the following XML code by default:
+ * 
+ * <TYPENAME>
+ *     <Name>NAME</Name>
+ *     <Value>VALUETEXT</Value>
+ * </TYPENAME>
  *
- * \param out The output device on which we serialize the parameter's state.
+ * with TYPENAME = typeName(),
+ *         NAME = name(), and
+ *    VALUETEXT = QString::number(value()).
+ *
+ * \param xmlWriter The QXMLStreamWriter, which we use serialize the 
+ *                  parameter's type, name and value.
  */
 void EnumParameter::serialize(QXmlStreamWriter& xmlWriter) const
 {
@@ -140,14 +150,14 @@ void EnumParameter::serialize(QXmlStreamWriter& xmlWriter) const
     
     xmlWriter.writeStartElement(typeName());
     xmlWriter.writeTextElement("Name", name());
-    xmlWriter.writeTextElement("Value", QString("%1").arg(value()));
+    xmlWriter.writeTextElement("Value", QString::number(value()));
     xmlWriter.writeEndElement();
 }
 
 /**
- * Deserialization of a parameter's state from an input device.
+ * Deserialization of a parameter's state from an xml file.
  *
- * \param in the input device.
+ * \param xmlReader The QXmlStreamReader, where we read from.
  * \return True, if the deserialization was successful, else false.
  */
 bool EnumParameter::deserialize(QXmlStreamReader& xmlReader)

--- a/src/core/parameters/enumparameter.cxx
+++ b/src/core/parameters/enumparameter.cxx
@@ -164,31 +164,31 @@ bool EnumParameter::deserialize(QXmlStreamReader& xmlReader)
 {
     try
     {
-        if(xmlReader.readNextStartElement())
+        if(     xmlReader.name() == typeName()
+            &&  xmlReader.attributes().hasAttribute("ID"))
         {
-            if(xmlReader.name() == typeName())
+            setID(xmlReader.attributes().value("ID").toString());
+            
+            while(xmlReader.readNextStartElement())
             {
-                while(xmlReader.readNextStartElement())
+                if(xmlReader.name() == "Name")
                 {
-                    if(xmlReader.name() == "Name")
-                    {
-                        setName(xmlReader.readElementText());
-                    }
-                    if(xmlReader.name() == "Value")
-                    {
-                        QString valueText =  xmlReader.readElementText();
-                        
-                        setValue(valueText.toInt());
-                        return isValid();
-                    }
+                    setName(xmlReader.readElementText());
+                }
+                if(xmlReader.name() == "Value")
+                {
+                    QString valueText =  xmlReader.readElementText();
+                    
+                    setValue(valueText.toInt());
+                    return isValid();
                 }
             }
         }
         else
         {
-            throw std::runtime_error("Did not find typeName() in XML tree");
+            throw std::runtime_error("Did not find typeName() or id() in XML tree");
         }
-        throw std::runtime_error("Did not find any start element in XML tree");
+        return false;
     }
     catch(std::runtime_error & e)
     {

--- a/src/core/parameters/enumparameter.cxx
+++ b/src/core/parameters/enumparameter.cxx
@@ -63,7 +63,7 @@ EnumParameter::EnumParameter(const QString& name, const QStringList & enum_names
 :	Parameter(name, parent, invert_parent),
     m_enum_names(enum_names),
     m_value(value),
-    m_cmbDelegate(NULL)
+    m_delegate(NULL)
 {
 }
 
@@ -72,8 +72,8 @@ EnumParameter::EnumParameter(const QString& name, const QStringList & enum_names
  */
 EnumParameter::~EnumParameter()
 {
-    if(m_cmbDelegate != NULL)
-        delete m_cmbDelegate;
+    if(m_delegate != NULL)
+        delete m_delegate;
 }
 
 /**
@@ -93,7 +93,7 @@ QString  EnumParameter::typeName() const
  */
 int EnumParameter::value() const
 {
-	return m_value;// m_cmbDelegate->currentIndex();
+	return m_value;// m_delegate->currentIndex();
 }
     
 /**
@@ -105,9 +105,9 @@ void EnumParameter::setValue(int value)
 {
     m_value = value;
     
-    if(m_cmbDelegate != NULL)
+    if(m_delegate != NULL)
     {
-    	m_cmbDelegate->setCurrentIndex(value);
+    	m_delegate->setCurrentIndex(value);
         Parameter::updateValue();
     }
 }
@@ -206,19 +206,19 @@ bool EnumParameter::isValid() const
  */
 QWidget*  EnumParameter::delegate()
 {
-    if(m_cmbDelegate == NULL)
+    if(m_delegate == NULL)
     {
-        m_cmbDelegate = new QComboBox;
+        m_delegate = new QComboBox;
         for(int v=0; v<m_enum_names.size(); ++v)
         {
-            m_cmbDelegate->addItem(m_enum_names[v]);
+            m_delegate->addItem(m_enum_names[v]);
         }
-        m_cmbDelegate->setCurrentIndex(m_value);
+        m_delegate->setCurrentIndex(m_value);
     
-        connect(m_cmbDelegate, SIGNAL(currentIndexChanged(int)), this, SLOT(updateValue()));
+        connect(m_delegate, SIGNAL(currentIndexChanged(int)), this, SLOT(updateValue()));
         Parameter::initConnections();
     }
-    return m_cmbDelegate;
+    return m_delegate;
 }
 
 /**
@@ -228,9 +228,9 @@ QWidget*  EnumParameter::delegate()
 void EnumParameter::updateValue()
 {
     //Should not happen - otherwise, better safe than sorry:
-    if(m_cmbDelegate != NULL)
+    if(m_delegate != NULL)
     {
-        m_value = m_cmbDelegate->currentIndex();
+        m_value = m_delegate->currentIndex();
         Parameter::updateValue();
     }
 }

--- a/src/core/parameters/enumparameter.cxx
+++ b/src/core/parameters/enumparameter.cxx
@@ -36,6 +36,7 @@
 #include "core/parameters/enumparameter.hxx"
 
 #include <QtDebug>
+#include <QXmlStreamWriter>
 
 /**
  * @file
@@ -133,10 +134,15 @@ QString EnumParameter::valueText() const
  *
  * \param out The output device on which we serialize the parameter's state.
  */
-void EnumParameter::serialize(QIODevice& out) const
+void EnumParameter::serialize(QXmlStreamWriter& xmlWriter) const
 {
-    Parameter::serialize(out);
-    write_on_device(", " + QString("%1").arg(value()), out);
+    
+    xmlWriter.setAutoFormatting(true);
+    
+    xmlWriter.writeStartElement(magicID());
+    xmlWriter.writeTextElement("Name", name());
+    xmlWriter.writeTextElement("Value", QString("%1").arg(value()));
+    xmlWriter.writeEndElement();
 }
 
 /**

--- a/src/core/parameters/enumparameter.hxx
+++ b/src/core/parameters/enumparameter.hxx
@@ -86,7 +86,7 @@ class GRAIPE_CORE_EXPORT EnumParameter
          *
          * \return "EnumParameter".
          */
-        static QString typeName();
+        virtual QString typeName() const;
     
         /** 
          * The current value of this parameter in the correct, most special type.

--- a/src/core/parameters/enumparameter.hxx
+++ b/src/core/parameters/enumparameter.hxx
@@ -160,7 +160,7 @@ class GRAIPE_CORE_EXPORT EnumParameter
         int m_value;
     
         /** The delegate widget **/
-        QPointer<QComboBox> m_cmbDelegate;
+        QPointer<QComboBox> m_delegate;
     
 };
 

--- a/src/core/parameters/enumparameter.hxx
+++ b/src/core/parameters/enumparameter.hxx
@@ -110,7 +110,7 @@ class GRAIPE_CORE_EXPORT EnumParameter
          *
          * \return The value of the parameter converted to an QString.
          */
-        QString valueText() const;
+        QString toString() const;
             
         /**
          * Serialization of the parameter's state to an output device.
@@ -126,7 +126,7 @@ class GRAIPE_CORE_EXPORT EnumParameter
          * \param in the input device.
          * \return True, if the deserialization was successful, else false.
          */
-        bool deserialize(QIODevice& in);
+        bool deserialize(QXmlStreamReader& xmlReader);
         
         /**
          * This function indicates whether the value of a parameter is valid or not.

--- a/src/core/parameters/enumparameter.hxx
+++ b/src/core/parameters/enumparameter.hxx
@@ -113,17 +113,27 @@ class GRAIPE_CORE_EXPORT EnumParameter
         QString toString() const;
             
         /**
-         * Serialization of the parameter's state to an output device.
-         * Basically, just: "EnumParameter: " + Index of enum
+         * Serialization of the parameter's state to a xml stream.
+         * Writes the following XML code by default:
+         * 
+         * <TYPENAME>
+         *     <Name>NAME</Name>
+         *     <Value>VALUETEXT</Value>
+         * </TYPENAME>
          *
-         * \param out The output device on which we serialize the parameter's state.
+         * with TYPENAME = typeName(),
+         *         NAME = name(), and
+         *    VALUETEXT = QString::number(value()).
+         *
+         * \param xmlWriter The QXMLStreamWriter, which we use serialize the 
+         *                  parameter's type, name and value.
          */
         void serialize(QXmlStreamWriter& xmlWriter) const;
     
         /**
-         * Deserialization of a parameter's state from an input device.
+         * Deserialization of a parameter's state from an xml file.
          *
-         * \param in the input device.
+         * \param xmlReader The QXmlStreamReader, where we read from.
          * \return True, if the deserialization was successful, else false.
          */
         bool deserialize(QXmlStreamReader& xmlReader);

--- a/src/core/parameters/enumparameter.hxx
+++ b/src/core/parameters/enumparameter.hxx
@@ -86,7 +86,7 @@ class GRAIPE_CORE_EXPORT EnumParameter
          *
          * \return "EnumParameter".
          */
-        virtual QString typeName() const;
+        static QString typeName();
     
         /** 
          * The current value of this parameter in the correct, most special type.

--- a/src/core/parameters/enumparameter.hxx
+++ b/src/core/parameters/enumparameter.hxx
@@ -118,7 +118,7 @@ class GRAIPE_CORE_EXPORT EnumParameter
          *
          * \param out The output device on which we serialize the parameter's state.
          */
-        void serialize(QIODevice& out) const;
+        void serialize(QXmlStreamWriter& xmlWriter) const;
     
         /**
          * Deserialization of a parameter's state from an input device.

--- a/src/core/parameters/filenameparameter.cxx
+++ b/src/core/parameters/filenameparameter.cxx
@@ -128,18 +128,6 @@ QString  FilenameParameter::valueText() const
 }
 
 /**
- * Serialization of the parameter's state to an output device.
- * Basically, just: "FilenameParameter, " + encode_string(value())
- *
- * \param out The output device on which we serialize the parameter's state.
- */
-void FilenameParameter::serialize(QIODevice& out) const
-{
-    Parameter::serialize(out);
-    write_on_device(", " + encode_string(value()), out);
-}
-
-/**
  * Deserialization of a parameter's state from an input device.
  *
  * \param in the input device.

--- a/src/core/parameters/filenameparameter.cxx
+++ b/src/core/parameters/filenameparameter.cxx
@@ -194,8 +194,7 @@ void FilenameParameter::updateValue()
     
         if(file.size())
         {
-            m_value = file;
-            Parameter::updateValue();
+            setValue(file);
         }
     }
 }

--- a/src/core/parameters/filenameparameter.cxx
+++ b/src/core/parameters/filenameparameter.cxx
@@ -177,6 +177,7 @@ QWidget*  FilenameParameter::delegate()
         connect(m_btnDelegate,  SIGNAL(clicked()), this, SLOT(updateValue()));
         Parameter::initConnections();
     }
+    
     return m_delegate;
 }
 

--- a/src/core/parameters/filenameparameter.cxx
+++ b/src/core/parameters/filenameparameter.cxx
@@ -83,7 +83,7 @@ FilenameParameter::~FilenameParameter()
  *
  * \return "FilenameParameter".
  */
-QString  FilenameParameter::typeName()
+QString  FilenameParameter::typeName() const
 {
     return "FilenameParameter";
 }

--- a/src/core/parameters/filenameparameter.cxx
+++ b/src/core/parameters/filenameparameter.cxx
@@ -122,10 +122,11 @@ void FilenameParameter::setValue(const QString & value)
  *
  * \return The value of the parameter converted to an QString.
  */
-QString  FilenameParameter::valueText() const
+QString  FilenameParameter::toString() const
 {
     return value();
 }
+
 
 /**
  * Deserialization of a parameter's state from an input device.
@@ -133,16 +134,9 @@ QString  FilenameParameter::valueText() const
  * \param in the input device.
  * \return True, if the deserialization was successful, else false.
  */
-bool FilenameParameter::deserialize(QIODevice& in)
+bool FilenameParameter::fromString(QString& str)
 {
-    if(!Parameter::deserialize(in))
-    {
-        return false;
-    }
-    
-    QString content(in.readLine().trimmed());
-    setValue(decode_string(content));
-    
+    setValue(str);
     return true;
 }
 

--- a/src/core/parameters/filenameparameter.cxx
+++ b/src/core/parameters/filenameparameter.cxx
@@ -83,7 +83,7 @@ FilenameParameter::~FilenameParameter()
  *
  * \return "FilenameParameter".
  */
-QString  FilenameParameter::typeName() const
+QString  FilenameParameter::typeName()
 {
     return "FilenameParameter";
 }

--- a/src/core/parameters/filenameparameter.cxx
+++ b/src/core/parameters/filenameparameter.cxx
@@ -129,9 +129,9 @@ QString  FilenameParameter::toString() const
 
 
 /**
- * Deserialization of a parameter's state from an input device.
+ * Deserialization of a parameter's state from a string.
  *
- * \param in the input device.
+ * \param str the input QString.
  * \return True, if the deserialization was successful, else false.
  */
 bool FilenameParameter::fromString(QString& str)

--- a/src/core/parameters/filenameparameter.hxx
+++ b/src/core/parameters/filenameparameter.hxx
@@ -87,7 +87,7 @@ class GRAIPE_CORE_EXPORT FilenameParameter
          *
          * \return "FilenameParameter".
          */
-        QString typeName() const;
+        static QString typeName();
         
         /** 
          * The current value of this parameter in the correct, most special type.

--- a/src/core/parameters/filenameparameter.hxx
+++ b/src/core/parameters/filenameparameter.hxx
@@ -103,22 +103,24 @@ class GRAIPE_CORE_EXPORT FilenameParameter
          */
         void setValue(const QString& value);
             
+            
         /**
          * The value converted to a QString. Please note, that this can vary from the 
          * serialize() result, which also returns a QString. This is due to the fact,
          * that serialize also may perform encoding of QStrings to avoid special chars
-         * inside the QString.
+         * inside the QString
          *
-         * \return The value of the parameter converted to an QString.
+         * \return The value of the parameter converted to an QString
          */
-        QString valueText() const;
+        QString toString() const;
+    
         /**
          * Deserialization of a parameter's state from an input device.
          *
          * \param in the input device.
          * \return True, if the deserialization was successful, else false.
          */
-        bool deserialize(QIODevice& in);
+        bool fromString(QString& str);
     
         /**
          * This function indicates whether the value of a parameter is valid or not.

--- a/src/core/parameters/filenameparameter.hxx
+++ b/src/core/parameters/filenameparameter.hxx
@@ -115,9 +115,9 @@ class GRAIPE_CORE_EXPORT FilenameParameter
         QString toString() const;
     
         /**
-         * Deserialization of a parameter's state from an input device.
+         * Deserialization of a parameter's state from a string.
          *
-         * \param in the input device.
+         * \param str the input QString.
          * \return True, if the deserialization was successful, else false.
          */
         bool fromString(QString& str);

--- a/src/core/parameters/filenameparameter.hxx
+++ b/src/core/parameters/filenameparameter.hxx
@@ -87,7 +87,7 @@ class GRAIPE_CORE_EXPORT FilenameParameter
          *
          * \return "FilenameParameter".
          */
-        static QString typeName();
+        virtual QString typeName() const;
         
         /** 
          * The current value of this parameter in the correct, most special type.

--- a/src/core/parameters/filenameparameter.hxx
+++ b/src/core/parameters/filenameparameter.hxx
@@ -112,15 +112,6 @@ class GRAIPE_CORE_EXPORT FilenameParameter
          * \return The value of the parameter converted to an QString.
          */
         QString valueText() const;
-            
-        /**
-         * Serialization of the parameter's state to an output device.
-         * Basically, just: "FilenameParameter, " + encode_string(value())
-         *
-         * \param out The output device on which we serialize the parameter's state.
-         */
-        void serialize(QIODevice& out) const;
-    
         /**
          * Deserialization of a parameter's state from an input device.
          *

--- a/src/core/parameters/floatparameter.cxx
+++ b/src/core/parameters/floatparameter.cxx
@@ -64,7 +64,7 @@ FloatParameter::FloatParameter(const QString& name, float low, float upp, float 
     m_value(value),
     m_min_value(low),
     m_max_value(upp),
-    m_dsbDelegate(NULL)
+    m_delegate(NULL)
 {
 }
 
@@ -73,8 +73,8 @@ FloatParameter::FloatParameter(const QString& name, float low, float upp, float 
  */
 FloatParameter::~FloatParameter()
 {
-    if(m_dsbDelegate != NULL)
-        delete m_dsbDelegate;
+    if(m_delegate != NULL)
+        delete m_delegate;
 }
 
 /**
@@ -106,8 +106,8 @@ void FloatParameter::setLowerBound(float value)
 {
     m_min_value = value;
     
-    if(m_dsbDelegate != NULL)
-        m_dsbDelegate->setMinimum(value);
+    if(m_delegate != NULL)
+        m_delegate->setMinimum(value);
 }
 
 /**
@@ -129,8 +129,8 @@ void FloatParameter::setUpperBound(float value)
 {
     m_max_value = value;
     
-    if(m_dsbDelegate != NULL)
-        m_dsbDelegate->setMaximum(value);
+    if(m_delegate != NULL)
+        m_delegate->setMaximum(value);
 }
 
 /**
@@ -152,7 +152,7 @@ void FloatParameter::setRange(float min_value, float max_value)
  */
 float FloatParameter::value() const
 {
-    return m_value;//m_dsbDelegate->value();
+    return m_value;//m_delegate->value();
 }
 
 /**
@@ -164,9 +164,9 @@ void FloatParameter::setValue(float value)
 {
     m_value = value;
     
-    if(m_dsbDelegate != NULL)
+    if(m_delegate != NULL)
     {
-        m_dsbDelegate->setValue(value);
+        m_delegate->setValue(value);
         Parameter::updateValue();
     }
 }
@@ -227,18 +227,18 @@ bool FloatParameter::isValid() const
  */
 QWidget*  FloatParameter::delegate()
 {
-    if(m_dsbDelegate == NULL)
+    if(m_delegate == NULL)
     {
-        m_dsbDelegate = new QDoubleSpinBox;
+        m_delegate = new QDoubleSpinBox;
    
-        m_dsbDelegate->setDecimals(3);
-        m_dsbDelegate->setRange(lowerBound(), upperBound());
-        m_dsbDelegate->setValue(value());
+        m_delegate->setDecimals(3);
+        m_delegate->setRange(lowerBound(), upperBound());
+        m_delegate->setValue(value());
         
-        connect(m_dsbDelegate, SIGNAL(valueChanged(double)), this, SLOT(updateValue()));
+        connect(m_delegate, SIGNAL(valueChanged(double)), this, SLOT(updateValue()));
         Parameter::initConnections();
     }
-    return m_dsbDelegate;
+    return m_delegate;
 }
 
 /**
@@ -248,9 +248,9 @@ QWidget*  FloatParameter::delegate()
 void FloatParameter::updateValue()
 {
     //Should not happen - otherwise, better safe than sorry:
-    if(m_dsbDelegate != NULL)
+    if(m_delegate != NULL)
     {
-        m_value = m_dsbDelegate->value();
+        m_value = m_delegate->value();
         Parameter::updateValue();
     }
 }

--- a/src/core/parameters/floatparameter.cxx
+++ b/src/core/parameters/floatparameter.cxx
@@ -82,7 +82,7 @@ FloatParameter::~FloatParameter()
  *
  * \return "FloatParameter".
  */
-QString FloatParameter::typeName()
+QString FloatParameter::typeName() const
 {
 	return "FloatParameter";
 }

--- a/src/core/parameters/floatparameter.cxx
+++ b/src/core/parameters/floatparameter.cxx
@@ -185,9 +185,9 @@ QString  FloatParameter::toString() const
 }
 
 /**
- * Deserialization of a parameter's state from an input device.
+ * Deserialization of a parameter's state from a string.
  *
- * \param in the input device.
+ * \param str the input QString.
  * \return True, if the deserialization was successful, else false.
  */
 bool FloatParameter::fromString(QString& str)

--- a/src/core/parameters/floatparameter.cxx
+++ b/src/core/parameters/floatparameter.cxx
@@ -179,7 +179,7 @@ void FloatParameter::setValue(float value)
  *
  * \return The value of the parameter converted to an QString.
  */
-QString  FloatParameter::valueText() const
+QString  FloatParameter::toString() const
 {
 	return QString::number(value(),'g', 10);
 }
@@ -190,29 +190,22 @@ QString  FloatParameter::valueText() const
  * \param in the input device.
  * \return True, if the deserialization was successful, else false.
  */
-bool FloatParameter::deserialize(QIODevice& in)
+bool FloatParameter::fromString(QString& str)
 {
-    if(!Parameter::deserialize(in))
-    {
-        return false;
-    }
-    
-    QString content(in.readLine().trimmed());
-    
     try
     {
-        
-        float val = content.toFloat();
+        double val = str.toFloat();
         setValue(val);
         
         return true;
     }
     catch (...)
     {
-        qCritical() << "FloatParameter deserialize: value could not be imported from: '" << content << "'";
+        qCritical() << "FloatParameter deserialize: value could not be imported from: '" << str << "'";
     }
     return false;
 }
+
 
 /**
  * This function indicates whether the value of a parameter is valid or not.

--- a/src/core/parameters/floatparameter.cxx
+++ b/src/core/parameters/floatparameter.cxx
@@ -82,7 +82,7 @@ FloatParameter::~FloatParameter()
  *
  * \return "FloatParameter".
  */
-QString  FloatParameter::typeName() const
+QString FloatParameter::typeName()
 {
 	return "FloatParameter";
 }

--- a/src/core/parameters/floatparameter.cxx
+++ b/src/core/parameters/floatparameter.cxx
@@ -185,18 +185,6 @@ QString  FloatParameter::valueText() const
 }
 
 /**
- * Serialization of the parameter's state to an output device.
- * Basically, just: "FloatParameter, " + valueText()
- *
- * \param out The output device on which we serialize the parameter's state.
- */
-void FloatParameter::serialize(QIODevice& out) const
-{
-    Parameter::serialize(out);
-    write_on_device(", " + valueText(), out);
-}
-
-/**
  * Deserialization of a parameter's state from an input device.
  *
  * \param in the input device.

--- a/src/core/parameters/floatparameter.hxx
+++ b/src/core/parameters/floatparameter.hxx
@@ -138,16 +138,16 @@ class GRAIPE_CORE_EXPORT FloatParameter
          * \param value The new value of this parameter.
          */
         void setValue(float value);
-    
+            
         /**
          * The value converted to a QString. Please note, that this can vary from the 
          * serialize() result, which also returns a QString. This is due to the fact,
          * that serialize also may perform encoding of QStrings to avoid special chars
-         * inside the QString.
+         * inside the QString
          *
-         * \return The value of the parameter converted to an QString.
+         * \return The value of the parameter converted to an QString
          */
-        QString valueText() const;
+        QString toString() const;
     
         /**
          * Deserialization of a parameter's state from an input device.
@@ -155,7 +155,7 @@ class GRAIPE_CORE_EXPORT FloatParameter
          * \param in the input device.
          * \return True, if the deserialization was successful, else false.
          */
-        bool deserialize(QIODevice& in);
+        bool fromString(QString& str);
     
         /**
          * This function indicates whether the value of a parameter is valid or not.

--- a/src/core/parameters/floatparameter.hxx
+++ b/src/core/parameters/floatparameter.hxx
@@ -87,7 +87,7 @@ class GRAIPE_CORE_EXPORT FloatParameter
          *
          * \return "FloatParameter".
          */
-        QString typeName() const;
+        static QString typeName();
         
         /**
          * The lowest possible value of this parameter.

--- a/src/core/parameters/floatparameter.hxx
+++ b/src/core/parameters/floatparameter.hxx
@@ -87,7 +87,7 @@ class GRAIPE_CORE_EXPORT FloatParameter
          *
          * \return "FloatParameter".
          */
-        static QString typeName();
+        virtual QString typeName() const;
         
         /**
          * The lowest possible value of this parameter.

--- a/src/core/parameters/floatparameter.hxx
+++ b/src/core/parameters/floatparameter.hxx
@@ -189,7 +189,7 @@ class GRAIPE_CORE_EXPORT FloatParameter
         float m_min_value, m_max_value;
     
         /** The delegate widget **/
-        QPointer<QDoubleSpinBox> m_dsbDelegate;
+        QPointer<QDoubleSpinBox> m_delegate;
 };
 
 } //end of namespace graipe

--- a/src/core/parameters/floatparameter.hxx
+++ b/src/core/parameters/floatparameter.hxx
@@ -150,9 +150,9 @@ class GRAIPE_CORE_EXPORT FloatParameter
         QString toString() const;
     
         /**
-         * Deserialization of a parameter's state from an input device.
+         * Deserialization of a parameter's state from a string.
          *
-         * \param in the input device.
+         * \param str the input QString.
          * \return True, if the deserialization was successful, else false.
          */
         bool fromString(QString& str);

--- a/src/core/parameters/floatparameter.hxx
+++ b/src/core/parameters/floatparameter.hxx
@@ -148,14 +148,6 @@ class GRAIPE_CORE_EXPORT FloatParameter
          * \return The value of the parameter converted to an QString.
          */
         QString valueText() const;
-            
-        /**
-         * Serialization of the parameter's state to an output device.
-         * Basically, just: "FloatParameter, " + valueText()
-         *
-         * \param out The output device on which we serialize the parameter's state.
-         */
-        void serialize(QIODevice& out) const;
     
         /**
          * Deserialization of a parameter's state from an input device.

--- a/src/core/parameters/intparameter.cxx
+++ b/src/core/parameters/intparameter.cxx
@@ -176,7 +176,7 @@ void IntParameter::setValue(int value)
  *
  * \return The value of the parameter converted to an QString.
  */
-QString  IntParameter::valueText() const
+QString  IntParameter::toString() const
 {
 	return QString("%1").arg(value());
 }
@@ -187,26 +187,18 @@ QString  IntParameter::valueText() const
  * \param in the input device.
  * \return True, if the deserialization was successful, else false.
  */
-bool IntParameter::deserialize(QIODevice& in)
+bool IntParameter::fromString(QString& str)
 {
-    if(!Parameter::deserialize(in))
-    {
-        return false;
-    }
-    
-    QString content(in.readLine().trimmed());
-
     try
     {
-        int val = content.toInt();
+        double val = str.toInt();
         setValue(val);
         
         return true;
     }
     catch (...)
     {
-        
-        qCritical() << "IntParameter deserialize: value could not be imported from '" << content <<"'";
+        qCritical() << "IntParameter deserialize: value could not be imported from: '" << str << "'";
     }
     return false;
 }

--- a/src/core/parameters/intparameter.cxx
+++ b/src/core/parameters/intparameter.cxx
@@ -64,7 +64,7 @@ IntParameter::IntParameter(const QString& name, int low, int upp, int value, Par
     m_value(value),
     m_min_value(low),
     m_max_value(upp),
-    m_spbDelegate(NULL)
+    m_delegate(NULL)
 {
 }
 
@@ -73,8 +73,8 @@ IntParameter::IntParameter(const QString& name, int low, int upp, int value, Par
  */
 IntParameter::~IntParameter()
 {
-    if(m_spbDelegate != NULL)
-        delete m_spbDelegate;
+    if(m_delegate != NULL)
+        delete m_delegate;
 }
 
 /**
@@ -106,8 +106,8 @@ void IntParameter::setLowerBound(int value)
 {
     m_min_value = value;
 
-    if(m_spbDelegate != NULL)
-        m_spbDelegate->setMinimum(value);
+    if(m_delegate != NULL)
+        m_delegate->setMinimum(value);
 }
 
 /**
@@ -129,8 +129,8 @@ void IntParameter::setUpperBound(int value)
 {
     m_max_value = value;
 
-    if(m_spbDelegate != NULL)
-        m_spbDelegate->setMaximum(value);
+    if(m_delegate != NULL)
+        m_delegate->setMaximum(value);
 }
 
 /**
@@ -164,8 +164,8 @@ void IntParameter::setValue(int value)
 {
     m_value = value;
     
-    if(m_spbDelegate != NULL)
-        m_spbDelegate->setValue(value);
+    if(m_delegate != NULL)
+        m_delegate->setValue(value);
 }
 
 /**
@@ -223,17 +223,17 @@ bool IntParameter::isValid() const
  */
 QWidget*  IntParameter::delegate()
 {
-    if(m_spbDelegate == NULL)
+    if(m_delegate == NULL)
     {
-        m_spbDelegate = new QSpinBox;
+        m_delegate = new QSpinBox;
    
-        m_spbDelegate->setRange(lowerBound(), upperBound());
-        m_spbDelegate->setValue(value());
+        m_delegate->setRange(lowerBound(), upperBound());
+        m_delegate->setValue(value());
         
-        connect(m_spbDelegate, SIGNAL(valueChanged(int)), this, SLOT(updateValue()));
+        connect(m_delegate, SIGNAL(valueChanged(int)), this, SLOT(updateValue()));
         Parameter::initConnections();
     }
-    return m_spbDelegate;
+    return m_delegate;
 }
 
 /**
@@ -243,9 +243,9 @@ QWidget*  IntParameter::delegate()
 void IntParameter::updateValue()
 {
     //Should not happen - otherwise, better safe than sorry:
-    if(m_spbDelegate != NULL)
+    if(m_delegate != NULL)
     {
-        m_value = m_spbDelegate->value();
+        m_value = m_delegate->value();
         Parameter::updateValue();
     }
 }

--- a/src/core/parameters/intparameter.cxx
+++ b/src/core/parameters/intparameter.cxx
@@ -182,18 +182,6 @@ QString  IntParameter::valueText() const
 }
 
 /**
- * Serialization of the parameter's state to an output device.
- * Basically, just: "IntParameter, " + valueText()
- *
- * \param out The output device on which we serialize the parameter's state.
- */
-void IntParameter::serialize(QIODevice& out) const
-{
-    Parameter::serialize(out);
-    write_on_device(", "+ valueText(), out);
-}
-
-/**
  * Deserialization of a parameter's state from an input device.
  *
  * \param in the input device.

--- a/src/core/parameters/intparameter.cxx
+++ b/src/core/parameters/intparameter.cxx
@@ -82,7 +82,7 @@ IntParameter::~IntParameter()
  *
  * \return "IntParameter".
  */
-QString  IntParameter::typeName()
+QString  IntParameter::typeName() const
 {
 	return "IntParameter";
 }

--- a/src/core/parameters/intparameter.cxx
+++ b/src/core/parameters/intparameter.cxx
@@ -182,9 +182,9 @@ QString  IntParameter::toString() const
 }
 
 /**
- * Deserialization of a parameter's state from an input device.
+ * Deserialization of a parameter's state from a string.
  *
- * \param in the input device.
+ * \param str the input QString.
  * \return True, if the deserialization was successful, else false.
  */
 bool IntParameter::fromString(QString& str)

--- a/src/core/parameters/intparameter.cxx
+++ b/src/core/parameters/intparameter.cxx
@@ -82,7 +82,7 @@ IntParameter::~IntParameter()
  *
  * \return "IntParameter".
  */
-QString  IntParameter::typeName() const
+QString  IntParameter::typeName()
 {
 	return "IntParameter";
 }

--- a/src/core/parameters/intparameter.hxx
+++ b/src/core/parameters/intparameter.hxx
@@ -188,7 +188,7 @@ class GRAIPE_CORE_EXPORT IntParameter
         int m_min_value, m_max_value;
     
         /** The delegate widget **/
-        QPointer<QSpinBox> m_spbDelegate;
+        QPointer<QSpinBox> m_delegate;
 };
 
 } //end of namespace graipe

--- a/src/core/parameters/intparameter.hxx
+++ b/src/core/parameters/intparameter.hxx
@@ -149,14 +149,6 @@ class GRAIPE_CORE_EXPORT IntParameter
         QString valueText() const;
     
         /**
-         * Serialization of the parameter's state to an output device.
-         * Basically, just: "IntParameter, " + valueText()
-         *
-         * \param out The output device on which we serialize the parameter's state.
-         */
-        void serialize(QIODevice& out) const;
-    
-        /**
          * Deserialization of a parameter's state from an input device.
          *
          * \param in the input device.

--- a/src/core/parameters/intparameter.hxx
+++ b/src/core/parameters/intparameter.hxx
@@ -137,16 +137,16 @@ class GRAIPE_CORE_EXPORT IntParameter
          * \param value The new value of this parameter.
          */
         void setValue(int value);
-    
+            
         /**
          * The value converted to a QString. Please note, that this can vary from the 
          * serialize() result, which also returns a QString. This is due to the fact,
          * that serialize also may perform encoding of QStrings to avoid special chars
-         * inside the QString.
+         * inside the QString
          *
-         * \return The value of the parameter converted to an QString.
+         * \return The value of the parameter converted to an QString
          */
-        QString valueText() const;
+        QString toString() const;
     
         /**
          * Deserialization of a parameter's state from an input device.
@@ -154,7 +154,7 @@ class GRAIPE_CORE_EXPORT IntParameter
          * \param in the input device.
          * \return True, if the deserialization was successful, else false.
          */
-        bool deserialize(QIODevice& in);
+        bool fromString(QString& str);
     
         /**
          * This function indicates whether the value of a parameter is valid or not.

--- a/src/core/parameters/intparameter.hxx
+++ b/src/core/parameters/intparameter.hxx
@@ -87,7 +87,7 @@ class GRAIPE_CORE_EXPORT IntParameter
          *
          * \return "IntParameter".
          */
-        QString typeName() const;
+        static QString typeName();
         /**
          * The lowest possible value of this parameter.
          *

--- a/src/core/parameters/intparameter.hxx
+++ b/src/core/parameters/intparameter.hxx
@@ -149,9 +149,9 @@ class GRAIPE_CORE_EXPORT IntParameter
         QString toString() const;
     
         /**
-         * Deserialization of a parameter's state from an input device.
+         * Deserialization of a parameter's state from a string.
          *
-         * \param in the input device.
+         * \param str the input QString.
          * \return True, if the deserialization was successful, else false.
          */
         bool fromString(QString& str);

--- a/src/core/parameters/intparameter.hxx
+++ b/src/core/parameters/intparameter.hxx
@@ -87,7 +87,7 @@ class GRAIPE_CORE_EXPORT IntParameter
          *
          * \return "IntParameter".
          */
-        static QString typeName();
+        virtual QString typeName() const;
         /**
          * The lowest possible value of this parameter.
          *

--- a/src/core/parameters/longstringparameter.cxx
+++ b/src/core/parameters/longstringparameter.cxx
@@ -83,7 +83,7 @@ LongStringParameter::~LongStringParameter()
  *
  * \return "LongStringParameter".
  */
-QString  LongStringParameter::typeName()
+QString  LongStringParameter::typeName() const
 {
     return "LongStringParameter";
 }

--- a/src/core/parameters/longstringparameter.cxx
+++ b/src/core/parameters/longstringparameter.cxx
@@ -127,19 +127,6 @@ QString  LongStringParameter::valueText() const
 }
 
 /**
- * Serialization of the parameter's state to an output device.
- * Basically, just: "LongStringParameter, " + encode_string(value())
- *
- * \param out The output device on which we serialize the parameter's state.
- */
-void LongStringParameter::serialize(QIODevice& out) const
-{
-    Parameter::serialize(out);
-    
-    write_on_device(", " + encode_string(value()), out);
-}
-
-/**
  * Deserialization of a parameter's state from an input device.
  *
  * \param in the input device.

--- a/src/core/parameters/longstringparameter.cxx
+++ b/src/core/parameters/longstringparameter.cxx
@@ -121,27 +121,19 @@ void LongStringParameter::setValue(const QString & value)
  *
  * \return The value of the parameter converted to an QString.
  */
-QString  LongStringParameter::valueText() const
+QString  LongStringParameter::toString() const
 {
     return value();
 }
 
 /**
- * Deserialization of a parameter's state from an input device.
+ * Sets the value using a QString. This is the default method, used by the desearialize .
  *
- * \param in the input device.
- * \return True, if the deserialization was successful, else false.
+ * \param str The value of the parameter converted to an QString
  */
-bool LongStringParameter::deserialize(QIODevice& in)
+bool LongStringParameter::fromString(QString& str)
 {
-    if(!Parameter::deserialize(in))
-    {
-        return false;
-    }
-    
-    QString content(in.readLine().trimmed());
-    setValue(decode_string(content));
-    
+    setValue(str);
     return true;
 }
 

--- a/src/core/parameters/longstringparameter.cxx
+++ b/src/core/parameters/longstringparameter.cxx
@@ -83,7 +83,7 @@ LongStringParameter::~LongStringParameter()
  *
  * \return "LongStringParameter".
  */
-QString  LongStringParameter::typeName() const
+QString  LongStringParameter::typeName()
 {
     return "LongStringParameter";
 }

--- a/src/core/parameters/longstringparameter.cxx
+++ b/src/core/parameters/longstringparameter.cxx
@@ -65,7 +65,7 @@ LongStringParameter::LongStringParameter(const QString& name, const QString& val
     m_value(value),
     m_columns(columns),
     m_lines(lines),
-    m_txtDelegate(NULL)
+    m_delegate(NULL)
 {
 }
 
@@ -74,8 +74,8 @@ LongStringParameter::LongStringParameter(const QString& name, const QString& val
  */
 LongStringParameter::~LongStringParameter()
 {
-    if(m_txtDelegate != NULL)
-        delete m_txtDelegate;
+    if(m_delegate != NULL)
+        delete m_delegate;
 }
 
 /**
@@ -107,9 +107,9 @@ void LongStringParameter::setValue(const QString & value)
 {
     m_value = value;
     
-    if(m_txtDelegate != NULL)
+    if(m_delegate != NULL)
     {
-        m_txtDelegate->setPlainText(value);
+        m_delegate->setPlainText(value);
     }
 }
 
@@ -157,18 +157,18 @@ bool LongStringParameter::isValid() const
  */
 QWidget*  LongStringParameter::delegate()
 {
-    if(m_txtDelegate == NULL)
+    if(m_delegate == NULL)
     {
-        m_txtDelegate = new QPlainTextEdit;
+        m_delegate = new QPlainTextEdit;
     
-        m_txtDelegate->setMinimumWidth(m_columns * m_txtDelegate->fontMetrics().width("X"));
-        m_txtDelegate->setMinimumHeight(m_lines * m_txtDelegate->fontMetrics().lineSpacing());
-        m_txtDelegate->setPlainText(m_value);
+        m_delegate->setMinimumWidth(m_columns * m_delegate->fontMetrics().width("X"));
+        m_delegate->setMinimumHeight(m_lines * m_delegate->fontMetrics().lineSpacing());
+        m_delegate->setPlainText(m_value);
     
-        connect(m_txtDelegate, SIGNAL(textChanged()), this, SLOT(updateValue()));
+        connect(m_delegate, SIGNAL(textChanged()), this, SLOT(updateValue()));
         Parameter::initConnections();
     }
-    return m_txtDelegate;
+    return m_delegate;
 }
 
 /**
@@ -178,9 +178,9 @@ QWidget*  LongStringParameter::delegate()
 void LongStringParameter::updateValue()
 {
     //Should not happen - otherwise, better safe than sorry:
-    if(m_txtDelegate != NULL)
+    if(m_delegate != NULL)
     {
-        m_value = m_txtDelegate->toPlainText();
+        m_value = m_delegate->toPlainText();
         Parameter::updateValue();
     }
 }

--- a/src/core/parameters/longstringparameter.hxx
+++ b/src/core/parameters/longstringparameter.hxx
@@ -109,11 +109,11 @@ class GRAIPE_CORE_EXPORT LongStringParameter
          * The value converted to a QString. Please note, that this can vary from the 
          * serialize() result, which also returns a QString. This is due to the fact,
          * that serialize also may perform encoding of QStrings to avoid special chars
-         * inside the QString.
+         * inside the QString
          *
-         * \return The value of the parameter converted to an QString.
+         * \return The value of the parameter converted to an QString
          */
-        QString valueText() const;
+        QString toString() const;
     
         /**
          * Deserialization of a parameter's state from an input device.
@@ -121,7 +121,7 @@ class GRAIPE_CORE_EXPORT LongStringParameter
          * \param in the input device.
          * \return True, if the deserialization was successful, else false.
          */
-        bool deserialize(QIODevice& in);
+        bool fromString(QString& str);
     
         /**
          * This function indicates whether the value of a parameter is valid or not.

--- a/src/core/parameters/longstringparameter.hxx
+++ b/src/core/parameters/longstringparameter.hxx
@@ -158,7 +158,7 @@ class GRAIPE_CORE_EXPORT LongStringParameter
         unsigned int m_lines;
     
         /** The text editing delegate **/
-        QPointer<QPlainTextEdit> m_txtDelegate;
+        QPointer<QPlainTextEdit> m_delegate;
     
 };
 

--- a/src/core/parameters/longstringparameter.hxx
+++ b/src/core/parameters/longstringparameter.hxx
@@ -114,14 +114,6 @@ class GRAIPE_CORE_EXPORT LongStringParameter
          * \return The value of the parameter converted to an QString.
          */
         QString valueText() const;
-        
-        /**
-         * Serialization of the parameter's state to an output device.
-         * Basically, just: "LongStringParameter, " + encode_string(value())
-         *
-         * \param out The output device on which we serialize the parameter's state.
-         */
-        void serialize(QIODevice& out) const;
     
         /**
          * Deserialization of a parameter's state from an input device.

--- a/src/core/parameters/longstringparameter.hxx
+++ b/src/core/parameters/longstringparameter.hxx
@@ -89,7 +89,7 @@ class GRAIPE_CORE_EXPORT LongStringParameter
          *
          * \return "LongStringParameter".
          */
-        static QString typeName();
+        virtual QString typeName() const;
     
         /** 
          * The current value of this parameter in the correct, most special type.

--- a/src/core/parameters/longstringparameter.hxx
+++ b/src/core/parameters/longstringparameter.hxx
@@ -116,9 +116,9 @@ class GRAIPE_CORE_EXPORT LongStringParameter
         QString toString() const;
     
         /**
-         * Deserialization of a parameter's state from an input device.
+         * Deserialization of a parameter's state from a string.
          *
-         * \param in the input device.
+         * \param str the input QString.
          * \return True, if the deserialization was successful, else false.
          */
         bool fromString(QString& str);

--- a/src/core/parameters/longstringparameter.hxx
+++ b/src/core/parameters/longstringparameter.hxx
@@ -89,7 +89,7 @@ class GRAIPE_CORE_EXPORT LongStringParameter
          *
          * \return "LongStringParameter".
          */
-        QString typeName() const;
+        static QString typeName();
     
         /** 
          * The current value of this parameter in the correct, most special type.

--- a/src/core/parameters/modelparameter.cxx
+++ b/src/core/parameters/modelparameter.cxx
@@ -271,6 +271,7 @@ QWidget*  ModelParameter::delegate()
         connect(m_cmbDelegate, SIGNAL(currentIndexChanged(int)), this, SLOT(updateValue()));
         Parameter::initConnections();
     }
+    
     return m_cmbDelegate;
 }
 

--- a/src/core/parameters/modelparameter.cxx
+++ b/src/core/parameters/modelparameter.cxx
@@ -35,6 +35,7 @@
 #include "core/parameters/modelparameter.hxx"
 
 #include <QtDebug>
+#include <QXmlStreamWriter>
 
 /**
  * @file
@@ -194,10 +195,15 @@ void ModelParameter::refresh()
  *
  * \param out The output device on which we serialize the parameter's state.
  */
-void ModelParameter::serialize(QIODevice& out) const
+void ModelParameter::serialize(QXmlStreamWriter& xmlWriter) const
 {
-    Parameter::serialize(out);
-    write_on_device(", " + encode_string(value()->filename()), out);
+    
+    xmlWriter.setAutoFormatting(true);
+    
+    xmlWriter.writeStartElement(magicID());
+    xmlWriter.writeTextElement("Name", name());
+    xmlWriter.writeTextElement("Value", value()->filename());
+    xmlWriter.writeEndElement();
 }
 
 /**

--- a/src/core/parameters/modelparameter.cxx
+++ b/src/core/parameters/modelparameter.cxx
@@ -32,7 +32,9 @@
 /*    OTHER DEALINGS IN THE SOFTWARE.                                   */
 /*                                                                      */
 /************************************************************************/
+
 #include "core/parameters/modelparameter.hxx"
+#include "core/globals.hxx"
 
 #include <QtDebug>
 #include <QXmlStreamWriter>
@@ -59,15 +61,12 @@ namespace graipe {
  *                       be enabled/disabled, if the parent is a BoolParameter.
  * \param invert_parent  If true, the enables/disabled dependency to the parent will be swapped.
  */
-ModelParameter::ModelParameter(const QString &name, const std::vector<Model*> * rs_object_stack, QString type_filter, Model* value, Parameter* parent, bool invert_parent)
+ModelParameter::ModelParameter(const QString &name, QString type_filter, Model* value, Parameter* parent, bool invert_parent)
 :   Parameter(name, parent, invert_parent),
     m_cmbDelegate(NULL),
     m_type_filter(type_filter)
 {
-
-    setModelList(rs_object_stack);
 	refresh();
-    
     setValue(value);
     
 }
@@ -179,11 +178,11 @@ bool ModelParameter::fromString(QString& str)
  */
 void ModelParameter::refresh()
 {
-	if(m_modelList)
+	if(models.size())
 	{
 		m_allowed_values.clear();
 		
-		for(Model * model: *m_modelList)
+		for(Model * model: models)
 		{
             
 			if(m_type_filter.isEmpty() || m_type_filter.contains(model->typeName()))

--- a/src/core/parameters/modelparameter.cxx
+++ b/src/core/parameters/modelparameter.cxx
@@ -147,9 +147,29 @@ void ModelParameter::setValue(Model* value)
  *
  * \return The value of the parameter converted to an QString.
  */
-QString ModelParameter::valueText() const
+QString ModelParameter::toString() const
 { 
-	return value()->name();
+	return value()->filename();
+}
+/**
+ * Deserialization of a parameter's state from an input device.
+ *
+ * \param in the input device.
+ * \return True, if the deserialization was successful, else false.
+ */
+bool ModelParameter::fromString(QString& str)
+{
+    for(Model* allowed: m_allowed_values)
+    {
+        if (allowed->filename() == str)
+        {
+            setValue(allowed);
+            return true;
+        }
+    }
+    
+    qDebug() << "ModelParameter deserialize: filename does not match any given. Was: '" << str << "'";
+    return false;
 }
 
 /**
@@ -189,58 +209,6 @@ void ModelParameter::refresh()
         setValue(m_allowed_values[0]);
 }
 
-/**
- * Serialization of the parameter's state to an output device.
- * Basically: "ModelParameter, " + model->fielname()
- *
- * \param out The output device on which we serialize the parameter's state.
- */
-void ModelParameter::serialize(QXmlStreamWriter& xmlWriter) const
-{
-    
-    xmlWriter.setAutoFormatting(true);
-    
-    xmlWriter.writeStartElement(magicID());
-    xmlWriter.writeTextElement("Name", name());
-    xmlWriter.writeTextElement("Value", value()->filename());
-    xmlWriter.writeEndElement();
-}
-
-/**
- * Deserialization of a parameter's state from an input device.
- *
- * \param in the input device.
- * \return True, if the deserialization was successful, else false.
- */
-bool ModelParameter::deserialize(QIODevice& in)
-{
-    if(!Parameter::deserialize(in))
-    {
-        return false;
-    }
-    
-    bool found = false;
-    unsigned int i=0;
-    
-    QString content(in.readLine().trimmed());
-    
-    for(Model* allowed: m_allowed_values)
-    {
-        if (allowed->filename() == decode_string(content))
-        {
-            setValue(allowed);
-            found = true;
-        }
-        i++;
-    }
-    
-    if (!found)
-    {
-        qDebug() << "ModelParameter deserialize: filename does not match any given. Was: '" << content << "'";
-    }
-    
-    return found;
-}
 
 /**
  * This function locks the parameters value. 

--- a/src/core/parameters/modelparameter.cxx
+++ b/src/core/parameters/modelparameter.cxx
@@ -98,7 +98,7 @@ ModelParameter::~ModelParameter()
  *
  * \return "ModelParameter".
  */
-QString  ModelParameter::typeName() const
+QString  ModelParameter::typeName()
 {
 	return "ModelParameter";
 }

--- a/src/core/parameters/modelparameter.cxx
+++ b/src/core/parameters/modelparameter.cxx
@@ -148,7 +148,7 @@ void ModelParameter::setValue(Model* value)
  */
 QString ModelParameter::toString() const
 { 
-	return value()->filename();
+	return value()->id();
 }
 /**
  * Deserialization of a parameter's state from an input device.
@@ -160,7 +160,7 @@ bool ModelParameter::fromString(QString& str)
 {
     for(Model* allowed: m_allowed_values)
     {
-        if (allowed->filename() == str)
+        if (allowed->id() == str)
         {
             setValue(allowed);
             return true;

--- a/src/core/parameters/modelparameter.cxx
+++ b/src/core/parameters/modelparameter.cxx
@@ -98,7 +98,7 @@ ModelParameter::~ModelParameter()
  *
  * \return "ModelParameter".
  */
-QString  ModelParameter::typeName()
+QString  ModelParameter::typeName() const
 {
 	return "ModelParameter";
 }

--- a/src/core/parameters/modelparameter.cxx
+++ b/src/core/parameters/modelparameter.cxx
@@ -63,7 +63,7 @@ namespace graipe {
  */
 ModelParameter::ModelParameter(const QString &name, QString type_filter, Model* value, Parameter* parent, bool invert_parent)
 :   Parameter(name, parent, invert_parent),
-    m_cmbDelegate(NULL),
+    m_delegate(NULL),
     m_type_filter(type_filter)
 {
 	refresh();
@@ -76,8 +76,8 @@ ModelParameter::ModelParameter(const QString &name, QString type_filter, Model* 
  */
 ModelParameter::~ModelParameter()
 {
-    if(m_cmbDelegate != NULL)
-        delete m_cmbDelegate;
+    if(m_delegate != NULL)
+        delete m_delegate;
 }
 
 /**
@@ -126,9 +126,9 @@ void ModelParameter::setValue(Model* value)
         }
     }
     
-    if (found && m_cmbDelegate != NULL)
+    if (found && m_delegate != NULL)
     {
-        m_cmbDelegate->setCurrentIndex(m_model_idx);
+        m_delegate->setCurrentIndex(m_model_idx);
         Parameter::updateValue();
     }
     
@@ -192,16 +192,16 @@ void ModelParameter::refresh()
 		}
 	}
     
-    if(m_cmbDelegate)
+    if(m_delegate)
 	{
-		m_cmbDelegate->clear();
+		m_delegate->clear();
 		
         int i=0;
         
 		for(Model * model: m_allowed_values)
 		{
-			m_cmbDelegate->addItem(model->shortName());
-            m_cmbDelegate->setItemData(i++, model->description(), Qt::ToolTipRole);
+			m_delegate->addItem(model->shortName());
+            m_delegate->setItemData(i++, model->description(), Qt::ToolTipRole);
 		}
     }
     if(m_allowed_values.size() != 0)
@@ -261,17 +261,17 @@ bool ModelParameter::isValid() const
  */
 QWidget*  ModelParameter::delegate()
 {
-    if(m_cmbDelegate == NULL)
+    if(m_delegate == NULL)
     {
-        m_cmbDelegate = new QComboBox;
-        m_cmbDelegate->update();
+        m_delegate = new QComboBox;
+        m_delegate->update();
         refresh();
     
-        connect(m_cmbDelegate, SIGNAL(currentIndexChanged(int)), this, SLOT(updateValue()));
+        connect(m_delegate, SIGNAL(currentIndexChanged(int)), this, SLOT(updateValue()));
         Parameter::initConnections();
     }
     
-    return m_cmbDelegate;
+    return m_delegate;
 }
 
 /**
@@ -281,9 +281,9 @@ QWidget*  ModelParameter::delegate()
 void ModelParameter::updateValue()
 {
     //Should not happen - otherwise, better safe than sorry:
-    if(m_cmbDelegate != NULL)
+    if(m_delegate != NULL)
     {
-        m_model_idx = m_cmbDelegate->currentIndex();
+        m_model_idx = m_delegate->currentIndex();
         Parameter::updateValue();
     }
 }

--- a/src/core/parameters/modelparameter.hxx
+++ b/src/core/parameters/modelparameter.hxx
@@ -177,7 +177,7 @@ class GRAIPE_CORE_EXPORT ModelParameter
         int m_model_idx;
     
         /** The model's delegate widget **/
-        QPointer<QComboBox> m_cmbDelegate;
+        QPointer<QComboBox> m_delegate;
     
         /** The allowed model pointers **/
         std::vector<Model*>	m_allowed_values;

--- a/src/core/parameters/modelparameter.hxx
+++ b/src/core/parameters/modelparameter.hxx
@@ -128,7 +128,7 @@ class GRAIPE_CORE_EXPORT ModelParameter
          *
          * \param out The output device on which we serialize the parameter's state.
          */
-        void serialize(QIODevice& out) const;
+        void serialize(QXmlStreamWriter& xmlWriter) const;
     
         /**
          * Deserialization of a parameter's state from an input device.

--- a/src/core/parameters/modelparameter.hxx
+++ b/src/core/parameters/modelparameter.hxx
@@ -89,7 +89,7 @@ class GRAIPE_CORE_EXPORT ModelParameter
          *
          * \return "ModelParameter".
          */
-        QString typeName() const;
+        static QString typeName();
         
         /** 
          * The current value of this parameter in the correct, most special type.

--- a/src/core/parameters/modelparameter.hxx
+++ b/src/core/parameters/modelparameter.hxx
@@ -104,16 +104,22 @@ class GRAIPE_CORE_EXPORT ModelParameter
          * \param value The new value of this parameter.
          */
         void setValue(Model* value);
-            
+    
         /**
          * The value converted to a QString. Please note, that this can vary from the 
          * serialize() result, which also returns a QString. This is due to the fact,
-         * that serialize also may perform encoding of QStrings to avoid special chars
-         * inside the QString.
+         * that serialize also may perform encoding of QStrings to avoid special chars.
          *
-         * \return The value of the parameter converted to an QString.
+         * \return The value of the parameter converted to an QString
          */
-        QString valueText() const;
+        QString toString() const;
+    
+        /**
+         * Sets the value using a QString. This is the default method, used by the desearialize .
+         *
+         * \param str The value of the parameter converted to an QString
+         */
+        bool fromString(QString& str);
     
         /**
          * This method is called after each (re-)assignment of the model list
@@ -121,22 +127,6 @@ class GRAIPE_CORE_EXPORT ModelParameter
          * It synchronizes the list of available models with the widget's list.
          */
         void refresh();
-        
-        /**
-         * Serialization of the parameter's state to an output device.
-         * Basically: "ModelParameter, " + model->fielname()
-         *
-         * \param out The output device on which we serialize the parameter's state.
-         */
-        void serialize(QXmlStreamWriter& xmlWriter) const;
-    
-        /**
-         * Deserialization of a parameter's state from an input device.
-         *
-         * \param in the input device.
-         * \return True, if the deserialization was successful, else false.
-         */
-        bool deserialize(QIODevice& in);
     
         /**
          * This function locks the parameters value. 

--- a/src/core/parameters/modelparameter.hxx
+++ b/src/core/parameters/modelparameter.hxx
@@ -89,7 +89,7 @@ class GRAIPE_CORE_EXPORT ModelParameter
          *
          * \return "ModelParameter".
          */
-        static QString typeName();
+        virtual QString typeName() const;
         
         /** 
          * The current value of this parameter in the correct, most special type.

--- a/src/core/parameters/modelparameter.hxx
+++ b/src/core/parameters/modelparameter.hxx
@@ -77,7 +77,7 @@ class GRAIPE_CORE_EXPORT ModelParameter
          *                       be enabled/disabled, if the parent is a BoolParameter.
          * \param invert_parent  If true, the enables/disabled dependency to the parent will be swapped.
          */
-        ModelParameter(const QString& name, const std::vector<Model*> * allowed_models, QString type_filter="", Model* value=NULL, Parameter* parent=NULL, bool invert_parent=false);
+        ModelParameter(const QString& name, QString type_filter="", Model* value=NULL, Parameter* parent=NULL, bool invert_parent=false);
     
         /**
          * The destructor of the ModelParameter class

--- a/src/core/parameters/modelparameter.hxx
+++ b/src/core/parameters/modelparameter.hxx
@@ -115,18 +115,12 @@ class GRAIPE_CORE_EXPORT ModelParameter
         QString toString() const;
     
         /**
-         * Sets the value using a QString. This is the default method, used by the desearialize .
+         * Deserialization of a parameter's state from a string.
          *
-         * \param str The value of the parameter converted to an QString
+         * \param str the input QString.
+         * \return True, if the deserialization was successful, else false.
          */
         bool fromString(QString& str);
-    
-        /**
-         * This method is called after each (re-)assignment of the model list
-         * e.g. after a call of the setModelList() function. 
-         * It synchronizes the list of available models with the widget's list.
-         */
-        void refresh();
     
         /**
          * This function locks the parameters value. 

--- a/src/core/parameters/multimodelparameter.cxx
+++ b/src/core/parameters/multimodelparameter.cxx
@@ -209,7 +209,7 @@ void MultiModelParameter::serialize(QXmlStreamWriter& xmlWriter) const
     
     xmlWriter.setAutoFormatting(true);
     
-    xmlWriter.writeStartElement(magicID());
+    xmlWriter.writeStartElement(typeName());
     xmlWriter.writeTextElement("Name", name());
     int i=0;
     for(const Model* model: value())
@@ -234,7 +234,7 @@ bool MultiModelParameter::deserialize(QXmlStreamReader& xmlReader)
     {
         if (xmlReader.readNextStartElement())
         {
-            if(xmlReader.name() == magicID())
+            if(xmlReader.name() == typeName())
             {
                 while(xmlReader.readNextStartElement())
                 {
@@ -267,13 +267,13 @@ bool MultiModelParameter::deserialize(QXmlStreamReader& xmlReader)
         }
         else
         {
-            throw std::runtime_error("Did not find magicID in XML tree");
+            throw std::runtime_error("Did not find typeName() in XML tree");
         }
         throw std::runtime_error("Did not find any start element in XML tree");
     }
     catch(std::runtime_error & e)
     {
-        qCritical() << "Parameter::deserialize failed! Was looking for magicID: " << magicID() << "Error: " << e.what();
+        qCritical() << "Parameter::deserialize failed! Was looking for typeName(): " << typeName() << "Error: " << e.what();
         return false;
     }
     return true;

--- a/src/core/parameters/multimodelparameter.cxx
+++ b/src/core/parameters/multimodelparameter.cxx
@@ -63,14 +63,14 @@ namespace graipe {
  */
 MultiModelParameter::MultiModelParameter(const QString& name, QString type_filter, std::vector<Model*> *  /*value*/, Parameter* parent, bool invert_parent)
 :	Parameter(name, parent, invert_parent),
-    m_lstDelegate(new QListWidget),
+    m_delegate(new QListWidget),
     m_allowed_values(models),
 	m_type_filter(type_filter)
 {
-    m_lstDelegate->setSelectionMode(QAbstractItemView::MultiSelection);
+    m_delegate->setSelectionMode(QAbstractItemView::MultiSelection);
     refresh();
     
-    connect(m_lstDelegate, SIGNAL(selectionChanged()), this, SLOT(updateValue()));
+    connect(m_delegate, SIGNAL(selectionChanged()), this, SLOT(updateValue()));
     Parameter::initConnections();
 }
 
@@ -79,8 +79,8 @@ MultiModelParameter::MultiModelParameter(const QString& name, QString type_filte
  */
 MultiModelParameter::~MultiModelParameter()
 {
-    if(m_lstDelegate != NULL)
-        delete m_lstDelegate;
+    if(m_delegate != NULL)
+        delete m_delegate;
 }
 
 /**
@@ -134,13 +134,13 @@ void MultiModelParameter::setValue(const std::vector<Model*>& value)
             }
         }
         m_model_idxs.push_back(i);
-        if(m_lstDelegate != NULL)
+        if(m_delegate != NULL)
         {
-            m_lstDelegate->item(i)->setSelected(found);
+            m_delegate->item(i)->setSelected(found);
         }
         i++;
     }
-    if(m_lstDelegate != NULL)
+    if(m_delegate != NULL)
     {
         Parameter::updateValue();
     }
@@ -185,14 +185,14 @@ void MultiModelParameter::refresh()
 		}
 	}
     
-	if(m_lstDelegate != NULL)
+	if(m_delegate != NULL)
 	{
-		m_lstDelegate->clear();
+		m_delegate->clear();
 		
 		for(Model* model: m_allowed_values)
 		{
-			m_lstDelegate->addItem(model->shortName());
-            m_lstDelegate->item(m_lstDelegate->count()-1)->setToolTip(model->description());
+			m_delegate->addItem(model->shortName());
+            m_delegate->item(m_delegate->count()-1)->setToolTip(model->description());
 		}
 	}
 }
@@ -253,7 +253,7 @@ bool MultiModelParameter::deserialize(QXmlStreamReader& xmlReader)
                         {
                            if (filename == allowed_model->filename())
                            {
-                                m_lstDelegate->item(i)->setSelected(true);
+                                m_delegate->item(i)->setSelected(true);
                                 break;
                             }
                             ++i;
@@ -339,18 +339,18 @@ bool MultiModelParameter::isValid() const
  */
 QWidget*  MultiModelParameter::delegate()
 {
-    if(m_lstDelegate == NULL)
+    if(m_delegate == NULL)
     {
-        m_lstDelegate = new QListWidget;
+        m_delegate = new QListWidget;
         
-        m_lstDelegate->setSelectionMode(QAbstractItemView::MultiSelection);
+        m_delegate->setSelectionMode(QAbstractItemView::MultiSelection);
         refresh();
     
-        connect(m_lstDelegate, SIGNAL(selectionChanged()), this, SLOT(updateValue()));
+        connect(m_delegate, SIGNAL(selectionChanged()), this, SLOT(updateValue()));
         Parameter::initConnections();
     }
     
-    return m_lstDelegate;
+    return m_delegate;
 }
 
 /**
@@ -360,13 +360,13 @@ QWidget*  MultiModelParameter::delegate()
 void MultiModelParameter::updateValue()
 {
     //Should not happen - otherwise, better safe than sorry:
-    if(m_lstDelegate != NULL)
+    if(m_delegate != NULL)
     {
         m_model_idxs.clear();
         
-        for(int i=0; i<m_lstDelegate->count(); ++i)
+        for(int i=0; i<m_delegate->count(); ++i)
         {
-            if(m_lstDelegate->item(i)->isSelected())
+            if(m_delegate->item(i)->isSelected())
             {
                 m_model_idxs.push_back(i);
             }

--- a/src/core/parameters/multimodelparameter.cxx
+++ b/src/core/parameters/multimodelparameter.cxx
@@ -348,6 +348,7 @@ QWidget*  MultiModelParameter::delegate()
         connect(m_lstDelegate, SIGNAL(selectionChanged()), this, SLOT(updateValue()));
         Parameter::initConnections();
     }
+    
     return m_lstDelegate;
 }
 

--- a/src/core/parameters/multimodelparameter.cxx
+++ b/src/core/parameters/multimodelparameter.cxx
@@ -95,7 +95,7 @@ MultiModelParameter::~MultiModelParameter()
  *
  * \return "MultiModelParameter".
  */
-QString  MultiModelParameter::typeName()
+QString  MultiModelParameter::typeName() const
 {
 	return "MultiModelParameter";
 }

--- a/src/core/parameters/multimodelparameter.cxx
+++ b/src/core/parameters/multimodelparameter.cxx
@@ -34,6 +34,7 @@
 /************************************************************************/
 
 #include "core/parameters/multimodelparameter.hxx"
+#include "core/globals.hxx"
 
 #include <QtDebug>
 #include <QXmlStreamWriter>
@@ -60,10 +61,10 @@ namespace graipe {
  *                       be enabled/disabled, if the parent is a BoolParameter.
  * \param invert_parent  If true, the enables/disabled dependency to the parent will be swapped.
  */
-MultiModelParameter::MultiModelParameter(const QString& name, const std::vector<Model*> * allowed_values, QString type_filter, std::vector<Model*> *  /*value*/, Parameter* parent, bool invert_parent)
+MultiModelParameter::MultiModelParameter(const QString& name, QString type_filter, std::vector<Model*> *  /*value*/, Parameter* parent, bool invert_parent)
 :	Parameter(name, parent, invert_parent),
     m_lstDelegate(new QListWidget),
-    m_allowed_values(*allowed_values),
+    m_allowed_values(models),
 	m_type_filter(type_filter)
 {
     m_lstDelegate->setSelectionMode(QAbstractItemView::MultiSelection);
@@ -171,11 +172,11 @@ QString MultiModelParameter::toString() const
  */
 void MultiModelParameter::refresh()
 {
-	if(m_modelList != NULL)
+	if(models.size())
 	{
 		m_allowed_values.clear();
 		
-		for(Model* model: *m_modelList)
+		for(Model* model: models)
 		{
 			if( m_type_filter.contains(model->typeName()))
 			{

--- a/src/core/parameters/multimodelparameter.cxx
+++ b/src/core/parameters/multimodelparameter.cxx
@@ -36,6 +36,7 @@
 #include "core/parameters/multimodelparameter.hxx"
 
 #include <QtDebug>
+#include <QXmlStreamWriter>
 
 /**
  * @file
@@ -203,14 +204,19 @@ void MultiModelParameter::refresh()
  *
  * \param out The output device on which we serialize the parameter's state.
  */
-void MultiModelParameter::serialize(QIODevice& out) const
+void MultiModelParameter::serialize(QXmlStreamWriter& xmlWriter) const
 {
-    Parameter::serialize(out);
     
+    xmlWriter.setAutoFormatting(true);
+    
+    xmlWriter.writeStartElement(magicID());
+    xmlWriter.writeTextElement("Name", name());
+    int i=0;
     for(const Model* model: value())
     {
-        write_on_device(", " + encode_string(model->filename()), out);
+        xmlWriter.writeTextElement(QString("value%1").arg(++i), model->filename());
     }
+    xmlWriter.writeEndElement();
 }
 
 /**

--- a/src/core/parameters/multimodelparameter.cxx
+++ b/src/core/parameters/multimodelparameter.cxx
@@ -95,7 +95,7 @@ MultiModelParameter::~MultiModelParameter()
  *
  * \return "MultiModelParameter".
  */
-QString  MultiModelParameter::typeName() const
+QString  MultiModelParameter::typeName()
 {
 	return "MultiModelParameter";
 }

--- a/src/core/parameters/multimodelparameter.cxx
+++ b/src/core/parameters/multimodelparameter.cxx
@@ -217,7 +217,7 @@ void MultiModelParameter::serialize(QXmlStreamWriter& xmlWriter) const
     {
         xmlWriter.writeStartElement("Value");
         xmlWriter.writeAttribute("ID", QString::number(i++));
-            xmlWriter.writeCharacters(model->filename());
+            xmlWriter.writeCharacters(model->id());
         xmlWriter.writeEndElement();
     }
     xmlWriter.writeEndElement();
@@ -245,13 +245,13 @@ bool MultiModelParameter::deserialize(QXmlStreamReader& xmlReader)
                     }
                     if(xmlReader.name() == "Value")
                     {
-                        QString filename =  xmlReader.readElementText();
+                        QString id =  xmlReader.readElementText();
                         
                         int i=0;
                         
                         for(const Model* allowed_model: m_allowed_values)
                         {
-                           if (filename == allowed_model->filename())
+                           if (id == allowed_model->id())
                            {
                                 m_delegate->item(i)->setSelected(true);
                                 break;
@@ -260,7 +260,7 @@ bool MultiModelParameter::deserialize(QXmlStreamReader& xmlReader)
                         }
                         if(i==m_allowed_values.size())
                         {
-                            throw std::runtime_error("Did not find a model with filename: " + filename.toStdString());
+                            throw std::runtime_error("Did not find a model with id: " + id.toStdString());
                         }
                     }
                 }

--- a/src/core/parameters/multimodelparameter.hxx
+++ b/src/core/parameters/multimodelparameter.hxx
@@ -113,7 +113,7 @@ class GRAIPE_CORE_EXPORT MultiModelParameter
          *
          * \return The value of the parameter converted to an QString.
          */
-        QString valueText() const;
+        QString toString() const;
     
         /**
          * This method is called after each (re-)assignment of the model list
@@ -138,7 +138,7 @@ class GRAIPE_CORE_EXPORT MultiModelParameter
          * \param in the input device.
          * \return True, if the deserialization was successful, else false.
          */
-        bool deserialize(QIODevice& in);
+        bool deserialize(QXmlStreamReader& xmlReader);
     
         /**
          * This function locks the parameters value. 

--- a/src/core/parameters/multimodelparameter.hxx
+++ b/src/core/parameters/multimodelparameter.hxx
@@ -89,7 +89,7 @@ class GRAIPE_CORE_EXPORT MultiModelParameter
          *
          * \return "MultiModelParameter".
          */
-        QString typeName() const;
+        static QString typeName();
         
         /** 
          * The current value of this parameter in the correct, most special type.

--- a/src/core/parameters/multimodelparameter.hxx
+++ b/src/core/parameters/multimodelparameter.hxx
@@ -89,7 +89,7 @@ class GRAIPE_CORE_EXPORT MultiModelParameter
          *
          * \return "MultiModelParameter".
          */
-        static QString typeName();
+        virtual QString typeName() const;
         
         /** 
          * The current value of this parameter in the correct, most special type.

--- a/src/core/parameters/multimodelparameter.hxx
+++ b/src/core/parameters/multimodelparameter.hxx
@@ -77,7 +77,7 @@ class GRAIPE_CORE_EXPORT MultiModelParameter
          *                       be enabled/disabled, if the parent is a BoolParameter.
          * \param invert_parent  If true, the enables/disabled dependency to the parent will be swapped.
          */
-        MultiModelParameter(const QString& name, const std::vector<Model*> * allowed_models, QString type_filter="", std::vector<Model*>* value=NULL, Parameter* parent=NULL, bool invert_parent=false);
+        MultiModelParameter(const QString& name, QString type_filter="", std::vector<Model*>* value=NULL, Parameter* parent=NULL, bool invert_parent=false);
     
         /**
          * Destructor of the MultiModel class

--- a/src/core/parameters/multimodelparameter.hxx
+++ b/src/core/parameters/multimodelparameter.hxx
@@ -189,7 +189,7 @@ class GRAIPE_CORE_EXPORT MultiModelParameter
         std::vector<int> m_model_idxs;
     
         /** The delegate list widget **/
-        QPointer<QListWidget> m_lstDelegate;
+        QPointer<QListWidget> m_delegate;
     
         /** A vector of all allowed models (listed) **/
         std::vector<Model*>	m_allowed_values;

--- a/src/core/parameters/multimodelparameter.hxx
+++ b/src/core/parameters/multimodelparameter.hxx
@@ -130,7 +130,7 @@ class GRAIPE_CORE_EXPORT MultiModelParameter
          *
          * \param out The output device on which we serialize the parameter's state.
          */
-        void serialize(QIODevice& out) const;
+        void serialize(QXmlStreamWriter& xmlWriter) const;
     
         /**
          * Deserialization of a parameter's state from an input device.

--- a/src/core/parameters/multimodelparameter.hxx
+++ b/src/core/parameters/multimodelparameter.hxx
@@ -114,28 +114,32 @@ class GRAIPE_CORE_EXPORT MultiModelParameter
          * \return The value of the parameter converted to an QString.
          */
         QString toString() const;
-    
-        /**
-         * This method is called after each (re-)assignment of the model list
-         * e.g. after a call of the setModelList() function. 
-         * It synchronizes the list of available models with the widget's list.
-         */
-        void refresh();
             
         /**
-         * Serialization of the parameter's state to an output device.
-         * Writes comman-separated model list the output device, containing the filename
-         * for each model, like:
-         * "MultModelParameter, file1.bla, file2.blubb"
+         * Serialization of the parameter's state to a xml stream.
+         * Writes the following XML code by default:
+         * 
+         * <MultiModelParameter>
+         *     <Name>NAME</Name>
+         *     <Values>N</Value>
+         *     <Value ID="0">VALUE_0_ID</Value>
+         *     ...
+         *     <Value ID="N-1">VALUE_N-1_ID</Value>
+         * </MultiModelParameter>
          *
-         * \param out The output device on which we serialize the parameter's state.
+         * with     NAME = name(),
+         *             N = QString::number(value().size()), and
+         *    VALUE_0_ID = values()[0]->id().
+         *
+         * \param xmlWriter The QXMLStreamWriter, which we use serialize the 
+         *                  parameter's type, name and value.
          */
         void serialize(QXmlStreamWriter& xmlWriter) const;
     
         /**
-         * Deserialization of a parameter's state from an input device.
+         * Deserialization of a parameter's state from an xml file.
          *
-         * \param in the input device.
+         * \param xmlReader The QXmlStreamReader, where we read from.
          * \return True, if the deserialization was successful, else false.
          */
         bool deserialize(QXmlStreamReader& xmlReader);

--- a/src/core/parameters/parameter.cxx
+++ b/src/core/parameters/parameter.cxx
@@ -33,14 +33,10 @@
 /*                                                                      */
 /************************************************************************/
 
-#include "core/parameters/parameter.hxx"
 #include "core/parameters/boolparameter.hxx"
 #include "core/model.hxx"
 
 #include <QtDebug>
-#include <QCoreApplication>
-#include <QXmlStreamReader>
-#include <QXmlStreamWriter>
 
 /**
  * @file
@@ -89,13 +85,13 @@ Parameter::~Parameter()
  *
  * \return "Parameter".
  */
-QString  Parameter::typeName() const
+QString Parameter::typeName() const
 {
 	return "Parameter";
 }
 
 /**
- * The name of this parameter. This name is used a label for the parameter.
+ * The name of this parameter. This name is used as a label for the parameter.
  *
  * \return The name of the parameter.
  */
@@ -136,11 +132,11 @@ bool Parameter::invertParent() const
 }
 
 /**
- * The value converted to a QString. Please note, that this can vary from the 
- * serialize() result, which also returns a QString. This is due to the fact,
- * that serialize also may perform encoding of QStrings to avoid special chars.
+ * The value converted to a QString. Needs to be specified for inheriting classes.
+ * This is the default method for the value serialization performed by
+ * serialize.
  *
- * \return The value of the parameter converted to an QString
+ * \return The value of the parameter converted to an QString, here "".
  */
 QString Parameter::toString() const
 {
@@ -148,9 +144,12 @@ QString Parameter::toString() const
 }
 
 /**
- * Sets the value using a QString. This is the default method, used by the desearialize .
+ * Sets the value using a QString. 
+ * This is the default method for the value deserialization performed by
+ * deserialize.
  *
  * \param str The value of the parameter converted to an QString
+ * \return True, if the value could be restored. Here, always true.
  */
 bool Parameter::fromString(QString& str)
 {
@@ -158,19 +157,20 @@ bool Parameter::fromString(QString& str)
 }
 
 /**
- * Serialization of the parameter's state to an output device.
- * Writes the following XML on the device:
+ * Serialization of the parameter's state to a xml stream.
+ * Writes the following XML code by default:
  * 
- * <MAGICID>
+ * <TYPENAME>
  *     <Name>NAME</Name>
  *     <Value>VALUETEXT</Value>
- * </MAGICID>
+ * </TYPENAME>
  *
- * with MAGICID = typeName(),
+ * with TYPENAME = typeName(),
  *         NAME = name(), and
  *    VALUETEXT = toString().
  *
- * \param out The output device on which we serialize the parameter's state.
+ * \param xmlWriter The QXMLStreamWriter, which we use serialize the 
+ *                  parameter's type, name and value.
  */
 void Parameter::serialize(QXmlStreamWriter& xmlWriter) const
 {
@@ -183,9 +183,9 @@ void Parameter::serialize(QXmlStreamWriter& xmlWriter) const
 }
 
 /**
- * Deserialization of a parameter's state from an input device.
+ * Deserialization of a parameter's state from an xml stream.
  *
- * \param in the input device.
+ * \param xmlReader The QXmlStreamReader from which we read.
  * \return True, if the deserialization was successful, else false.
  */
 bool Parameter::deserialize(QXmlStreamReader& xmlReader)
@@ -238,15 +238,6 @@ bool Parameter::deserialize(QXmlStreamReader& xmlReader)
         qCritical() << "Parameter::deserialize failed! Was looking for typeName(): " << typeName() << "Error: " << e.what();
         return false;
     }
-}
-
-/**
- * This method is called after each (re-)assignment of the model list
- * e.g. after a call of the setModelList() function. It may be implemented
- * by means of the subclasses to handle these updates.
- */
-void Parameter::refresh()
-{
 }
 
 /**

--- a/src/core/parameters/parameter.cxx
+++ b/src/core/parameters/parameter.cxx
@@ -177,6 +177,7 @@ void Parameter::serialize(QXmlStreamWriter& xmlWriter) const
     xmlWriter.setAutoFormatting(true);
     
     xmlWriter.writeStartElement(typeName());
+    xmlWriter.writeAttribute("ID", id());
     xmlWriter.writeTextElement("Name", name());
     xmlWriter.writeTextElement("Value", toString());
     xmlWriter.writeEndElement();
@@ -194,44 +195,43 @@ bool Parameter::deserialize(QXmlStreamReader& xmlReader)
     
     try
     {
-        if (xmlReader.readNextStartElement())
-        {            
-            if(xmlReader.name() == typeName())
+        if(     xmlReader.name() == typeName()
+            &&  xmlReader.attributes().hasAttribute("ID"))
+        {
+            setID(xmlReader.attributes().value("ID").toString());
+            
+            for(int i=0; i!=2; ++i)
             {
-                for(int i=0; i!=2; ++i)
+                xmlReader.readNextStartElement();
+            
+                if(xmlReader.name() == "Name")
                 {
-                    xmlReader.readNextStartElement();
-                
-                    if(xmlReader.name() == "Name")
-                    {
-                        setName(xmlReader.readElementText());
-                    }
-                    if(xmlReader.name() == "Value")
-                    {
-                        QString valueText =  xmlReader.readElementText();
-                        success = fromString(valueText);
-                    }
+                    setName(xmlReader.readElementText());
                 }
-                while(true)
+                if(xmlReader.name() == "Value")
                 {
-                    if(!xmlReader.readNext())
-                    {
-                        return false;
-                    }
-                    
-                    if(xmlReader.isEndElement() && xmlReader.name() == typeName())
-                    {
-                        break;
-                    }
+                    QString valueText =  xmlReader.readElementText();
+                    success = fromString(valueText);
                 }
-                return success;
             }
+            while(true)
+            {
+                if(!xmlReader.readNext())
+                {
+                    return false;
+                }
+                
+                if(xmlReader.isEndElement() && xmlReader.name() == typeName())
+                {
+                    break;
+                }
+            }
+            return success;
         }
         else
         {
-            throw std::runtime_error("Did not find typeName() in XML tree");
+            throw std::runtime_error("Did not find typeName() or id() in XML tree");
         }
-        throw std::runtime_error("Did not find any start element in XML tree");
     }
     catch(std::runtime_error & e)
     {

--- a/src/core/parameters/parameter.cxx
+++ b/src/core/parameters/parameter.cxx
@@ -85,7 +85,7 @@ Parameter::~Parameter()
  *
  * \return "Parameter".
  */
-QString Parameter::typeName()
+QString Parameter::typeName() const
 {
 	return "Parameter";
 }

--- a/src/core/parameters/parameter.cxx
+++ b/src/core/parameters/parameter.cxx
@@ -38,6 +38,7 @@
 #include "core/model.hxx"
 
 #include <QtDebug>
+#include <QCoreApplication>
 #include <QXmlStreamReader>
 #include <QXmlStreamWriter>
 
@@ -201,14 +202,18 @@ void Parameter::serialize(QXmlStreamWriter& xmlWriter) const
  */
 bool Parameter::deserialize(QXmlStreamReader& xmlReader)
 {
+    bool success = false;
+    
     try
     {
         if (xmlReader.readNextStartElement())
-        {
+        {            
             if(xmlReader.name() == magicID())
             {
-                while(xmlReader.readNextStartElement())
+                for(int i=0; i!=2; ++i)
                 {
+                    xmlReader.readNextStartElement();
+                
                     if(xmlReader.name() == "Name")
                     {
                         setName(xmlReader.readElementText());
@@ -216,9 +221,22 @@ bool Parameter::deserialize(QXmlStreamReader& xmlReader)
                     if(xmlReader.name() == "Value")
                     {
                         QString valueText =  xmlReader.readElementText();
-                        return fromString(valueText);
+                        success = fromString(valueText);
                     }
                 }
+                while(true)
+                {
+                    if(!xmlReader.readNext())
+                    {
+                        return false;
+                    }
+                    
+                    if(xmlReader.isEndElement() && xmlReader.name() == magicID())
+                    {
+                        break;
+                    }
+                }
+                return success;
             }
         }
         else
@@ -301,28 +319,6 @@ bool Parameter::isValid() const
 }
 
 /**
- * Sets a parameter to be hidden. 
- * Hidden parameters behave like visible parameters unless they are added to a
- * parameter group, where their delegates will not be shown.
- *
- * \param hide If true, the parameter will be hidden in a parameter group.
- */
-void Parameter::hide(bool hide)
-{
-    m_hide = hide;
-}
-
-/**
- * Is a parameter marked as "hidden" with respect to a parameter group?
- *
- * \return True, if the parameter will be hidden in a parameter group.
- */
-bool Parameter::isHidden() const
-{
-    return m_hide;
-}
-
-/**
  * The delegate widget of this parameter. 
  * Each parameter generates such a widget on demand, which refers to the
  * first call of this function. This is needed due to the executability of
@@ -374,6 +370,7 @@ void Parameter::initConnections()
             }
         }
     }
+    
 }
 
 } //end of namespace graipe

--- a/src/core/parameters/parameter.cxx
+++ b/src/core/parameters/parameter.cxx
@@ -85,7 +85,7 @@ Parameter::~Parameter()
  *
  * \return "Parameter".
  */
-QString Parameter::typeName() const
+QString Parameter::typeName()
 {
 	return "Parameter";
 }

--- a/src/core/parameters/parameter.cxx
+++ b/src/core/parameters/parameter.cxx
@@ -241,29 +241,6 @@ bool Parameter::deserialize(QXmlStreamReader& xmlReader)
 }
 
 /**
- * Const access to the model list, which is currently assigned to 
- * this parameter.
- *
- * \return A pointer to the current model list.
- */
-const std::vector<Model*> * Parameter::modelList() const
-{
-	return m_modelList;
-}
-
-/**
- * Writing access to the model list, which may be used to assign a new
- * or update the currently used model list of this parameter.
- *
- * \param new_model_list A pointer to the new model list.
- */
-void Parameter::setModelList(const std::vector<Model*> * new_obj_stack)
-{
-	m_modelList = new_obj_stack;
-	refresh();
-}
-
-/**
  * This method is called after each (re-)assignment of the model list
  * e.g. after a call of the setModelList() function. It may be implemented
  * by means of the subclasses to handle these updates.

--- a/src/core/parameters/parameter.cxx
+++ b/src/core/parameters/parameter.cxx
@@ -157,18 +157,6 @@ bool Parameter::fromString(QString& str)
     return true;
 }
 
-
-/**
- * The magicID of this parameter class. 
- * Implemented to fullfil the Serializable interface.
- *
- * \return The same as the typeName() function.
- */
-QString Parameter::magicID() const
-{
-    return typeName();
-}
-
 /**
  * Serialization of the parameter's state to an output device.
  * Writes the following XML on the device:
@@ -178,7 +166,7 @@ QString Parameter::magicID() const
  *     <Value>VALUETEXT</Value>
  * </MAGICID>
  *
- * with MAGICID = magicID(),
+ * with MAGICID = typeName(),
  *         NAME = name(), and
  *    VALUETEXT = toString().
  *
@@ -188,7 +176,7 @@ void Parameter::serialize(QXmlStreamWriter& xmlWriter) const
 {
     xmlWriter.setAutoFormatting(true);
     
-    xmlWriter.writeStartElement(magicID());
+    xmlWriter.writeStartElement(typeName());
     xmlWriter.writeTextElement("Name", name());
     xmlWriter.writeTextElement("Value", toString());
     xmlWriter.writeEndElement();
@@ -208,7 +196,7 @@ bool Parameter::deserialize(QXmlStreamReader& xmlReader)
     {
         if (xmlReader.readNextStartElement())
         {            
-            if(xmlReader.name() == magicID())
+            if(xmlReader.name() == typeName())
             {
                 for(int i=0; i!=2; ++i)
                 {
@@ -231,7 +219,7 @@ bool Parameter::deserialize(QXmlStreamReader& xmlReader)
                         return false;
                     }
                     
-                    if(xmlReader.isEndElement() && xmlReader.name() == magicID())
+                    if(xmlReader.isEndElement() && xmlReader.name() == typeName())
                     {
                         break;
                     }
@@ -241,13 +229,13 @@ bool Parameter::deserialize(QXmlStreamReader& xmlReader)
         }
         else
         {
-            throw std::runtime_error("Did not find magicID in XML tree");
+            throw std::runtime_error("Did not find typeName() in XML tree");
         }
         throw std::runtime_error("Did not find any start element in XML tree");
     }
     catch(std::runtime_error & e)
     {
-        qCritical() << "Parameter::deserialize failed! Was looking for magicID: " << magicID() << "Error: " << e.what();
+        qCritical() << "Parameter::deserialize failed! Was looking for typeName(): " << typeName() << "Error: " << e.what();
         return false;
     }
 }

--- a/src/core/parameters/parameter.hxx
+++ b/src/core/parameters/parameter.hxx
@@ -230,22 +230,6 @@ class GRAIPE_CORE_EXPORT Parameter
         virtual bool isValid() const;
     
         /**
-         * Sets a parameter to be hidden. 
-         * Hidden parameters behave like visible parameters unless they are added to a
-         * parameter group, where their delegates will not be shown.
-         *
-         * \param hide If true, the parameter will be hidden in a parameter group.
-         */
-        virtual void hide(bool hide);
-    
-        /**
-         * Is a parameter marked as "hidden" with respect to a parameter group?
-         *
-         * \return True, if the parameter will be hidden in a parameter group.
-         */
-        virtual bool isHidden() const;
-    
-        /**
          * The delegate widget of this parameter. 
          * Each parameter generates such a widget on demand, which refers to the
          * first call of this function. This is needed due to the executability of
@@ -285,9 +269,6 @@ class GRAIPE_CORE_EXPORT Parameter
     
         /** Should the enabled/disabled by parent rule be inverted? **/
         bool m_invert_parent;
-    
-        /** Shall the parameter be hidden inside a parameter group? **/
-        bool m_hide;
     
         /** The list of all currently loaded models **/
         const std::vector<Model*> * m_modelList;

--- a/src/core/parameters/parameter.hxx
+++ b/src/core/parameters/parameter.hxx
@@ -102,7 +102,7 @@ class GRAIPE_CORE_EXPORT Parameter
         QString typeName() const;
     
         /**
-         * The name of this parameter. This name is used a label for the parameter.
+         * The name of this parameter. This name is used as a label for the parameter.
          *
          * \return The name of the parameter.
          */
@@ -131,52 +131,49 @@ class GRAIPE_CORE_EXPORT Parameter
         virtual bool invertParent() const;
     
         /**
-         * The value converted to a QString. Please note, that this can vary from the 
-         * serialize() result, which also returns a QString. This is due to the fact,
-         * that serialize also may perform encoding of QStrings to avoid special chars.
+         * The value converted to a QString. Needs to be specified for inheriting classes.
+         * This is the default method for the value serialization performed by
+         * serialize.
          *
-         * \return The value of the parameter converted to an QString
+         * \return The value of the parameter converted to an QString, here "".
          */
         virtual QString toString() const;
     
         /**
-         * Sets the value using a QString. This is the default method, used by the desearialize .
+         * Sets the value using a QString. 
+         * This is the default method for the value deserialization performed by
+         * deserialize.
          *
          * \param str The value of the parameter converted to an QString
+         * \return True, if the value could be restored. Here, always true.
          */
         virtual bool fromString(QString& str);
 
         /**
-         * Serialization of the parameter's state to an output device.
-         * Writes the following XML on the device:
+         * Serialization of the parameter's state to a xml stream.
+         * Writes the following XML code by default:
          * 
-         * <MAGICID>
+         * <TYPENAME>
          *     <Name>NAME</Name>
          *     <Value>VALUETEXT</Value>
-         * </MAGICID>
+         * </TYPENAME>
          *
-         * with MAGICID = typeName(),
+         * with TYPENAME = typeName(),
          *         NAME = name(), and
          *    VALUETEXT = toString().
          *
-         * \param out The output device on which we serialize the parameter's state.
+         * \param xmlWriter The QXMLStreamWriter, which we use serialize the 
+         *                  parameter's type, name and value.
          */
         void serialize(QXmlStreamWriter& xmlWriter) const;
     
         /**
-         * Deserialization of a parameter's state from an input device.
+         * Deserialization of a parameter's state from an xml stream.
          *
-         * \param in the input device.
+         * \param xmlReader The QXmlStreamReader from which we read.
          * \return True, if the deserialization was successful, else false.
          */
         bool deserialize(QXmlStreamReader& xmlReader);
-        
-        /**
-         * This method is called after each (re-)assignment of the model list
-         * e.g. after a call of the setModelList() function. It may be implemented
-         * by means of the subclasses to handle these updates.
-         */
-        virtual void refresh();
     
         /**
          * This function locks the parameters value. 

--- a/src/core/parameters/parameter.hxx
+++ b/src/core/parameters/parameter.hxx
@@ -170,22 +170,6 @@ class GRAIPE_CORE_EXPORT Parameter
          * \return True, if the deserialization was successful, else false.
          */
         bool deserialize(QXmlStreamReader& xmlReader);
-
-        /**
-         * Const access to the model list, which is currently assigned to 
-         * this parameter.
-         *
-         * \return A pointer to the current model list.
-         */
-        const std::vector<Model*> * modelList() const;
-        
-        /**
-         * Writing access to the model list, which may be used to assign a new
-         * or update the currently used model list of this parameter.
-         *
-         * \param new_model_list A pointer to the new model list.
-         */
-        void setModelList(const std::vector<Model*> * new_model_list);
         
         /**
          * This method is called after each (re-)assignment of the model list
@@ -261,9 +245,6 @@ class GRAIPE_CORE_EXPORT Parameter
     
         /** Should the enabled/disabled by parent rule be inverted? **/
         bool m_invert_parent;
-    
-        /** The list of all currently loaded models **/
-        const std::vector<Model*> * m_modelList;
 };
 
 } //end of namespace graipe

--- a/src/core/parameters/parameter.hxx
+++ b/src/core/parameters/parameter.hxx
@@ -146,14 +146,23 @@ class GRAIPE_CORE_EXPORT Parameter
          * \return The same as the typeName() function.
          */
         QString magicID() const;
-    
+
         /**
          * Serialization of the parameter's state to an output device.
-         * Just writes the magicID a.k.a. typeName() on the device.
+         * Writes the following XML on the device:
+         * 
+         * <MAGICID>
+         *     <Name>NAME</Name>
+         *     <value>VALUETEXT</value>
+         * </MAGICID>
+         *
+         * with MAGICID = magicID(),
+         *         NAME = name(), and
+         *    VALUETEXT = valueText().
          *
          * \param out The output device on which we serialize the parameter's state.
          */
-        void serialize(QIODevice& out) const;
+        void serialize(QXmlStreamWriter& xmlWriter) const;
     
         /**
          * Deserialization of a parameter's state from an input device.

--- a/src/core/parameters/parameter.hxx
+++ b/src/core/parameters/parameter.hxx
@@ -99,7 +99,7 @@ class GRAIPE_CORE_EXPORT Parameter
          *
          * \return "Parameter".
          */
-        QString typeName() const;
+        static QString typeName();
     
         /**
          * The name of this parameter. This name is used as a label for the parameter.

--- a/src/core/parameters/parameter.hxx
+++ b/src/core/parameters/parameter.hxx
@@ -137,7 +137,14 @@ class GRAIPE_CORE_EXPORT Parameter
          *
          * \return The value of the parameter converted to an QString
          */
-        virtual QString valueText() const;
+        virtual QString toString() const;
+    
+        /**
+         * Sets the value using a QString. This is the default method, used by the desearialize .
+         *
+         * \param str The value of the parameter converted to an QString
+         */
+        virtual bool fromString(QString& str);
     
         /**
          * The magicID of this parameter class. 
@@ -153,12 +160,12 @@ class GRAIPE_CORE_EXPORT Parameter
          * 
          * <MAGICID>
          *     <Name>NAME</Name>
-         *     <value>VALUETEXT</value>
+         *     <Value>VALUETEXT</Value>
          * </MAGICID>
          *
          * with MAGICID = magicID(),
          *         NAME = name(), and
-         *    VALUETEXT = valueText().
+         *    VALUETEXT = toString().
          *
          * \param out The output device on which we serialize the parameter's state.
          */
@@ -170,7 +177,7 @@ class GRAIPE_CORE_EXPORT Parameter
          * \param in the input device.
          * \return True, if the deserialization was successful, else false.
          */
-        bool deserialize(QIODevice& in);
+        bool deserialize(QXmlStreamReader& xmlReader);
 
         /**
          * Const access to the model list, which is currently assigned to 

--- a/src/core/parameters/parameter.hxx
+++ b/src/core/parameters/parameter.hxx
@@ -99,7 +99,7 @@ class GRAIPE_CORE_EXPORT Parameter
          *
          * \return "Parameter".
          */
-        static QString typeName();
+        virtual QString typeName() const;
     
         /**
          * The name of this parameter. This name is used as a label for the parameter.

--- a/src/core/parameters/parameter.hxx
+++ b/src/core/parameters/parameter.hxx
@@ -145,14 +145,6 @@ class GRAIPE_CORE_EXPORT Parameter
          * \param str The value of the parameter converted to an QString
          */
         virtual bool fromString(QString& str);
-    
-        /**
-         * The magicID of this parameter class. 
-         * Implemented to fullfil the Serializable interface.
-         *
-         * \return The same as the typeName() function.
-         */
-        QString magicID() const;
 
         /**
          * Serialization of the parameter's state to an output device.
@@ -163,7 +155,7 @@ class GRAIPE_CORE_EXPORT Parameter
          *     <Value>VALUETEXT</Value>
          * </MAGICID>
          *
-         * with MAGICID = magicID(),
+         * with MAGICID = typeName(),
          *         NAME = name(), and
          *    VALUETEXT = toString().
          *

--- a/src/core/parameters/parametergroup.cxx
+++ b/src/core/parameters/parametergroup.cxx
@@ -254,7 +254,7 @@ QString ParameterGroup::valueText(const QString & filter_types) const
  */
 QString ParameterGroup::magicID() const
 {
-    return "";
+    return "ParameterGroup";
 }
 
 /**
@@ -266,17 +266,26 @@ QString ParameterGroup::magicID() const
  *
  * \param out The output device on which we serialize the parameter's state.
  */
-void ParameterGroup::serialize(QIODevice& out) const
+void ParameterGroup::serialize(QXmlStreamWriter& xmlWriter) const
 {
+    
+    xmlWriter.setAutoFormatting(true);
+    
+    xmlWriter.writeStartElement(magicID());
+    xmlWriter.writeTextElement("Name", name());
+    xmlWriter.writeTextElement("Parameters", QString::number(m_parameters.size()));
+    
     for(storage_type::const_iterator iter = m_parameters.begin();  iter != m_parameters.end(); ++iter)
     {
         if (iter->second)
-        {
-            write_on_device(iter->first + ": ", out);
-            iter->second->serialize(out);
-            write_on_device("\n", out);
+        {            
+            xmlWriter.writeStartElement("Parameter");
+            xmlWriter.writeAttribute("ID",iter->first);
+            iter->second->serialize(xmlWriter);
+            xmlWriter.writeEndElement();
         }
     }
+    xmlWriter.writeEndElement();
 }
 
 /**

--- a/src/core/parameters/parametergroup.cxx
+++ b/src/core/parameters/parametergroup.cxx
@@ -242,17 +242,6 @@ QString ParameterGroup::valueText(const QString & filter_types) const
 }
 
 /**
- * The magicID of this parameter class. 
- * Implemented to fullfil the Serializable interface.
- *
- * \return "", since a parameter group does not use any magicIDs.
- */
-QString ParameterGroup::magicID() const
-{
-    return "ParameterGroup";
-}
-
-/**
  * Serialization of the parameter's state to an output device.
  * This serializes each parameter in the group by means of its name and its serialization,
  * one per line, e.g. like:
@@ -266,14 +255,14 @@ void ParameterGroup::serialize(QXmlStreamWriter& xmlWriter) const
     
     xmlWriter.setAutoFormatting(true);
     
-    xmlWriter.writeStartElement(magicID());
+    xmlWriter.writeStartElement(typeName());
     xmlWriter.writeTextElement("Name", name());
     xmlWriter.writeTextElement("Parameters", QString::number(m_parameters.size()));
     
     for(storage_type::const_iterator iter = m_parameters.begin();  iter != m_parameters.end(); ++iter)
     {
         if (iter->second)
-        {            
+        {
             xmlWriter.writeStartElement("Parameter");
             xmlWriter.writeAttribute("ID",iter->first);
                 iter->second->serialize(xmlWriter);
@@ -295,14 +284,11 @@ bool ParameterGroup::deserialize(QXmlStreamReader& xmlReader)
     {
         if (xmlReader.readNextStartElement())
         {
-            qDebug() << "ParameterGroup::deserialize: readNextStartElement" << xmlReader.name();
-            
-            if(xmlReader.name() == magicID())
+            if(xmlReader.name() == typeName())
             {
                 for(int j=0; j!=2; ++j)
                 {
                     xmlReader.readNextStartElement();
-                    qDebug() << "ParameterGroup::deserialize: readNextStartElement" << xmlReader.name();
                     
                     if(xmlReader.name() == "Name")
                     {
@@ -325,8 +311,6 @@ bool ParameterGroup::deserialize(QXmlStreamReader& xmlReader)
                                 &&  xmlReader.attributes().hasAttribute("ID"))
                             {
                                 QString id = xmlReader.attributes().value("ID").toString();
-                                
-                                qDebug() << QString::number(i) << "ParameterGroup::deserialize: readNextStartElement" << xmlReader.name() << " ID= " << id;
                                
                                 if(!m_parameters[id]->deserialize(xmlReader))
                                 {
@@ -356,7 +340,7 @@ bool ParameterGroup::deserialize(QXmlStreamReader& xmlReader)
                                 return false;
                             }
                             
-                            if(xmlReader.isEndElement() && xmlReader.name() == magicID())
+                            if(xmlReader.isEndElement() && xmlReader.name() == typeName())
                             {
                                 break;
                             }
@@ -367,7 +351,7 @@ bool ParameterGroup::deserialize(QXmlStreamReader& xmlReader)
             }
             else
             {
-                throw std::runtime_error("Did not find magicID in XML tree");
+                throw std::runtime_error("Did not find typeName() in XML tree");
             }
         }
         else
@@ -377,7 +361,7 @@ bool ParameterGroup::deserialize(QXmlStreamReader& xmlReader)
     }
     catch(std::runtime_error & e)
     {
-        qCritical() << "ParameterGroup::deserialize failed! Was looking for magicID: " << magicID() << "Error: " << e.what();
+        qCritical() << "ParameterGroup::deserialize failed! Was looking for typeName(): " << typeName() << "Error: " << e.what();
         return false;
     }
     return true;

--- a/src/core/parameters/parametergroup.cxx
+++ b/src/core/parameters/parametergroup.cxx
@@ -86,7 +86,7 @@ ParameterGroup::~ParameterGroup()
  *
  * \return "ParameterGroup".
  */
-QString  ParameterGroup::typeName() const
+QString ParameterGroup::typeName()
 {
 	return "ParameterGroup";
 }

--- a/src/core/parameters/parametergroup.cxx
+++ b/src/core/parameters/parametergroup.cxx
@@ -86,7 +86,7 @@ ParameterGroup::~ParameterGroup()
  *
  * \return "ParameterGroup".
  */
-QString ParameterGroup::typeName()
+QString ParameterGroup::typeName() const
 {
 	return "ParameterGroup";
 }

--- a/src/core/parameters/parametergroup.cxx
+++ b/src/core/parameters/parametergroup.cxx
@@ -242,17 +242,30 @@ QString ParameterGroup::valueText(const QString & filter_types) const
 }
 
 /**
- * Serialization of the parameter's state to an output device.
- * This serializes each parameter in the group by means of its name and its serialization,
- * one per line, e.g. like:
- * "param1: StringParameter, bla"
- * "param2: PointParmaeter, ...."
+ * Serialization of the parameter groups's state to a xml stream.
+ * Writes the following XML code by default:
+ * 
+ * <ParameterGroup>
+ *     <Name>NAME</Name>
+ *     <Parameters>N</Parameters>
+ *     <Parameter ID="ID_PARAM_0">
+ *         PARAM_0_SERIALIZATION
+ *     </Parameter>
+ *     ...
+ *     <Parameter ID="ID_PARAM_N-1">
+ *         PARAM_N-1_SERIALIZATION
+ *      </Parameter>
+ * </ParameterGroup>
  *
- * \param out The output device on which we serialize the parameter's state.
+ * with                NAME = name(), and
+ *               ID_PARAM_0 = m_parameters.front()->first.
+ *    PARAM_0_SERIALIZATION = m_parameters.front()->second->serialize().
+ *
+ * \param xmlWriter The QXMLStreamWriter, which we use serialize the 
+ *                  parameter's type, name and value.
  */
 void ParameterGroup::serialize(QXmlStreamWriter& xmlWriter) const
 {
-    
     xmlWriter.setAutoFormatting(true);
     
     xmlWriter.writeStartElement(typeName());
@@ -273,9 +286,9 @@ void ParameterGroup::serialize(QXmlStreamWriter& xmlWriter) const
 }
 
 /**
- * Deserialization of a parameter's state from an input device.
+ * Deserialization of a parameter's state from an xml file.
  *
- * \param in the input device.
+ * \param xmlReader The QXmlStreamReader, where we read from.
  * \return True, if the deserialization was successful, else false.
  */
 bool ParameterGroup::deserialize(QXmlStreamReader& xmlReader)
@@ -365,19 +378,6 @@ bool ParameterGroup::deserialize(QXmlStreamReader& xmlReader)
         return false;
     }
     return true;
-}
-    
-/**
- * This method is called after each (re-)assignment of the model list
- * e.g. after a call of the setModelList() function. 
- * It synchronizes the list of available models with the widget's list.
- */
-void ParameterGroup::refresh()
-{
-    for(storage_type::iterator iter = m_parameters.begin();  iter != m_parameters.end(); ++iter)
-    {
-        iter->second->refresh();
-    }
 }
 
 /**

--- a/src/core/parameters/parametergroup.cxx
+++ b/src/core/parameters/parametergroup.cxx
@@ -376,7 +376,7 @@ void ParameterGroup::refresh()
 {
     for(storage_type::iterator iter = m_parameters.begin();  iter != m_parameters.end(); ++iter)
     {
-        iter->second->setModelList(m_modelList);
+        iter->second->refresh();
     }
 }
 

--- a/src/core/parameters/parametergroup.hxx
+++ b/src/core/parameters/parametergroup.hxx
@@ -176,7 +176,7 @@ class GRAIPE_CORE_EXPORT ParameterGroup
          *
          * \return The value of the parameter converted to an QString.
          */
-        QString valueText() const;
+        QString toString() const;
         
         /**
          * The value converted to a QString. Please note, that this can vary from the 
@@ -215,7 +215,7 @@ class GRAIPE_CORE_EXPORT ParameterGroup
          * \param in the input device.
          * \return True, if the deserialization was successful, else false.
          */
-        bool deserialize(QIODevice& in);
+        bool deserialize(QXmlStreamReader& xmlReader);
     
         /**
          * This method is called after each (re-)assignment of the model list

--- a/src/core/parameters/parametergroup.hxx
+++ b/src/core/parameters/parametergroup.hxx
@@ -101,7 +101,7 @@ class GRAIPE_CORE_EXPORT ParameterGroup
          *
          * \return "ParameterGroup".
          */
-        static QString typeName();
+        virtual QString typeName() const;
     
         /**
          * Add an already existing parameter to the ParameterGroup.

--- a/src/core/parameters/parametergroup.hxx
+++ b/src/core/parameters/parametergroup.hxx
@@ -207,7 +207,7 @@ class GRAIPE_CORE_EXPORT ParameterGroup
          *
          * \param out The output device on which we serialize the parameter's state.
          */
-        void serialize(QIODevice& out) const;
+        void serialize(QXmlStreamWriter& xmlWriter) const;
     
         /**
          * Deserialization of a parameter's state from an input device.

--- a/src/core/parameters/parametergroup.hxx
+++ b/src/core/parameters/parametergroup.hxx
@@ -101,7 +101,7 @@ class GRAIPE_CORE_EXPORT ParameterGroup
          *
          * \return "ParameterGroup".
          */
-        QString typeName() const;
+        static QString typeName();
     
         /**
          * Add an already existing parameter to the ParameterGroup.

--- a/src/core/parameters/parametergroup.hxx
+++ b/src/core/parameters/parametergroup.hxx
@@ -187,16 +187,7 @@ class GRAIPE_CORE_EXPORT ParameterGroup
          * \param filter_types Only special parameters are given out - filtered by their type. 
          * \return The value of the parameter converted to an QString.
          */
-        QString valueText(const QString & filter_types) const;
-            
-        /**
-         * The magicID of this parameter class. 
-         * Implemented to fullfil the Serializable interface.
-         *
-         * \return "", since a parameter group does not use any magicIDs.
-         */
-        QString magicID() const;
-    
+        QString valueText(const QString & filter_types) const;    
 
         /**
          * Serialization of the parameter's state to an output device.

--- a/src/core/parameters/parametergroup.hxx
+++ b/src/core/parameters/parametergroup.hxx
@@ -190,30 +190,37 @@ class GRAIPE_CORE_EXPORT ParameterGroup
         QString valueText(const QString & filter_types) const;    
 
         /**
-         * Serialization of the parameter's state to an output device.
-         * This serializes each parameter in the group by means of its name and its serialization,
-         * one per line, e.g. like:
-         * "param1: StringParameter, bla"
-         * "param2: PointParmaeter, ...."
+         * Serialization of the parameter groups's state to a xml stream.
+         * Writes the following XML code by default:
+         * 
+         * <ParameterGroup>
+         *     <Name>NAME</Name>
+         *     <Parameters>N</Parameters>
+         *     <Parameter ID="ID_PARAM_0">
+         *         PARAM_0_SERIALIZATION
+         *     </Parameter>
+         *     ...
+         *     <Parameter ID="ID_PARAM_N-1">
+         *         PARAM_N-1_SERIALIZATION
+         *      </Parameter>
+         * </ParameterGroup>
          *
-         * \param out The output device on which we serialize the parameter's state.
+         * with                NAME = name(), and
+         *               ID_PARAM_0 = m_parameters.front()->first.
+         *    PARAM_0_SERIALIZATION = m_parameters.front()->second->serialize().
+         *
+         * \param xmlWriter The QXMLStreamWriter, which we use serialize the 
+         *                  parameter's type, name and value.
          */
         void serialize(QXmlStreamWriter& xmlWriter) const;
     
         /**
-         * Deserialization of a parameter's state from an input device.
+         * Deserialization of a parameter's state from an xml file.
          *
-         * \param in the input device.
+         * \param xmlReader The QXmlStreamReader, where we read from.
          * \return True, if the deserialization was successful, else false.
          */
         bool deserialize(QXmlStreamReader& xmlReader);
-    
-        /**
-         * This method is called after each (re-)assignment of the model list
-         * e.g. after a call of the setModelList() function. 
-         * It synchronizes the list of available models with the widget's list.
-         */
-        void refresh();
         
         /**
          * The delegate widget of this parameter. 

--- a/src/core/parameters/pointfparameter.cxx
+++ b/src/core/parameters/pointfparameter.cxx
@@ -198,18 +198,18 @@ QString  PointFParameter::toString() const
  * Serialization of the parameter's state to an output device.
  * Writes the following XML on the device:
  * 
- * <MAGICID>
+ * <TYPENAME>
  *     <Name>NAME</Name>
  *     <x>X</x>
  *     <y>Y</y>
- * </MAGICID>
+ * </TYPENAME>
  *
- * with MAGICID = typeName(),
+ * with TYPENAME = typeName(),
  *         NAME = name(),
  *            X = value().x(), and
  *            Y = value().y().
  *
- * \param out The output device on which we serialize the parameter's state.
+ * \param xmlWriter The QXmlStreamWriter on which we serialize the parameter's state.
  */
 void PointFParameter::serialize(QXmlStreamWriter& xmlWriter) const
 {
@@ -222,11 +222,10 @@ void PointFParameter::serialize(QXmlStreamWriter& xmlWriter) const
     xmlWriter.writeEndElement();
 }
 
-
 /**
- * Deserialization of a parameter's state from an input device.
+ * Deserialization of a parameter's state from an xml file.
  *
- * \param in the input device.
+ * \param xmlReader The QXmlStreamReader, where we read from.
  * \return True, if the deserialization was successful, else false.
  */
 bool PointFParameter::deserialize(QXmlStreamReader& xmlReader)

--- a/src/core/parameters/pointfparameter.cxx
+++ b/src/core/parameters/pointfparameter.cxx
@@ -239,8 +239,10 @@ bool PointFParameter::deserialize(QXmlStreamReader& xmlReader)
             {
                 QPointF p;
                 
-                while(xmlReader.readNextStartElement())
+                for(int i=0; i!=3; ++i)
                 {
+                    xmlReader.readNextStartElement();
+                
                     if(xmlReader.name() == "Name")
                     {
                         setName(xmlReader.readElementText());
@@ -254,7 +256,19 @@ bool PointFParameter::deserialize(QXmlStreamReader& xmlReader)
                        p.setY(xmlReader.readElementText().toFloat());
                     }
                 }
-                
+                //Read until </PointFParameter> comes....
+                while(true)
+                {
+                    if(!xmlReader.readNext())
+                    {
+                        return false;
+                    }
+                    
+                    if(xmlReader.isEndElement() && xmlReader.name() == magicID())
+                    {
+                        break;
+                    }
+                }
                 setValue(p);
                 return true;
             }

--- a/src/core/parameters/pointfparameter.cxx
+++ b/src/core/parameters/pointfparameter.cxx
@@ -216,6 +216,7 @@ void PointFParameter::serialize(QXmlStreamWriter& xmlWriter) const
     xmlWriter.setAutoFormatting(true);
     
     xmlWriter.writeStartElement(typeName());
+    xmlWriter.writeAttribute("ID", id());
     xmlWriter.writeTextElement("Name", name());
     xmlWriter.writeTextElement("x", QString::number(value().x(),'g', 10));
     xmlWriter.writeTextElement("y", QString::number(value().y(),'g', 10));
@@ -232,51 +233,50 @@ bool PointFParameter::deserialize(QXmlStreamReader& xmlReader)
 {
     try
     {
-        if (xmlReader.readNextStartElement())
+        if(     xmlReader.name() == typeName()
+            &&  xmlReader.attributes().hasAttribute("ID"))
         {
-            if(xmlReader.name() == typeName())
+            setID(xmlReader.attributes().value("ID").toString());
+            
+            QPointF p;
+            
+            for(int i=0; i!=3; ++i)
             {
-                QPointF p;
-                
-                for(int i=0; i!=3; ++i)
+                xmlReader.readNextStartElement();
+            
+                if(xmlReader.name() == "Name")
                 {
-                    xmlReader.readNextStartElement();
-                
-                    if(xmlReader.name() == "Name")
-                    {
-                        setName(xmlReader.readElementText());
-                    }
-                    if(xmlReader.name() == "x")
-                    {
-                       p.setX(xmlReader.readElementText().toFloat());
-                    }
-                    if(xmlReader.name() == "y")
-                    {
-                       p.setY(xmlReader.readElementText().toFloat());
-                    }
+                    setName(xmlReader.readElementText());
                 }
-                //Read until </PointFParameter> comes....
-                while(true)
+                if(xmlReader.name() == "x")
                 {
-                    if(!xmlReader.readNext())
-                    {
-                        return false;
-                    }
-                    
-                    if(xmlReader.isEndElement() && xmlReader.name() == typeName())
-                    {
-                        break;
-                    }
+                   p.setX(xmlReader.readElementText().toFloat());
                 }
-                setValue(p);
-                return true;
+                if(xmlReader.name() == "y")
+                {
+                   p.setY(xmlReader.readElementText().toFloat());
+                }
             }
+            //Read until </PointFParameter> comes....
+            while(true)
+            {
+                if(!xmlReader.readNext())
+                {
+                    return false;
+                }
+                
+                if(xmlReader.isEndElement() && xmlReader.name() == typeName())
+                {
+                    break;
+                }
+            }
+            setValue(p);
+            return true;
         }
         else
         {
-            throw std::runtime_error("Did not find typeName() in XML tree");
+            throw std::runtime_error("Did not find typeName() or id() in XML tree");
         }
-        throw std::runtime_error("Did not find any start element in XML tree");
     }
     catch(std::runtime_error & e)
     {

--- a/src/core/parameters/pointfparameter.cxx
+++ b/src/core/parameters/pointfparameter.cxx
@@ -87,7 +87,7 @@ PointFParameter::~PointFParameter()
  *
  * \return "PointFParameter".
  */
-QString  PointFParameter::typeName() const
+QString  PointFParameter::typeName()
 {
     return "PointFParameter";
 }

--- a/src/core/parameters/pointfparameter.cxx
+++ b/src/core/parameters/pointfparameter.cxx
@@ -87,7 +87,7 @@ PointFParameter::~PointFParameter()
  *
  * \return "PointFParameter".
  */
-QString  PointFParameter::typeName()
+QString  PointFParameter::typeName() const
 {
     return "PointFParameter";
 }

--- a/src/core/parameters/pointfparameter.cxx
+++ b/src/core/parameters/pointfparameter.cxx
@@ -204,7 +204,7 @@ QString  PointFParameter::toString() const
  *     <y>Y</y>
  * </MAGICID>
  *
- * with MAGICID = magicID(),
+ * with MAGICID = typeName(),
  *         NAME = name(),
  *            X = value().x(), and
  *            Y = value().y().
@@ -215,7 +215,7 @@ void PointFParameter::serialize(QXmlStreamWriter& xmlWriter) const
 {
     xmlWriter.setAutoFormatting(true);
     
-    xmlWriter.writeStartElement(magicID());
+    xmlWriter.writeStartElement(typeName());
     xmlWriter.writeTextElement("Name", name());
     xmlWriter.writeTextElement("x", QString::number(value().x(),'g', 10));
     xmlWriter.writeTextElement("y", QString::number(value().y(),'g', 10));
@@ -235,7 +235,7 @@ bool PointFParameter::deserialize(QXmlStreamReader& xmlReader)
     {
         if (xmlReader.readNextStartElement())
         {
-            if(xmlReader.name() == magicID())
+            if(xmlReader.name() == typeName())
             {
                 QPointF p;
                 
@@ -264,7 +264,7 @@ bool PointFParameter::deserialize(QXmlStreamReader& xmlReader)
                         return false;
                     }
                     
-                    if(xmlReader.isEndElement() && xmlReader.name() == magicID())
+                    if(xmlReader.isEndElement() && xmlReader.name() == typeName())
                     {
                         break;
                     }
@@ -275,13 +275,13 @@ bool PointFParameter::deserialize(QXmlStreamReader& xmlReader)
         }
         else
         {
-            throw std::runtime_error("Did not find magicID in XML tree");
+            throw std::runtime_error("Did not find typeName() in XML tree");
         }
         throw std::runtime_error("Did not find any start element in XML tree");
     }
     catch(std::runtime_error & e)
     {
-        qCritical() << "PointFParameter::deserialize failed! Was looking for magicID: " << magicID() << "Error: " << e.what();
+        qCritical() << "PointFParameter::deserialize failed! Was looking for typeName(): " << typeName() << "Error: " << e.what();
         return false;
     }
 }

--- a/src/core/parameters/pointfparameter.cxx
+++ b/src/core/parameters/pointfparameter.cxx
@@ -194,19 +194,34 @@ QString  PointFParameter::valueText() const
 {
     return QString("(") + QString::number(value().x(),'g', 10) + "x" + QString::number(value().y(),'g', 10) + ")";
 }
-
 /**
  * Serialization of the parameter's state to an output device.
- * Basically, it's just: "PointFParameter" + valueText()
+ * Writes the following XML on the device:
+ * 
+ * <MAGICID>
+ *     <Name>NAME</Name>
+ *     <x>X</x>
+ *     <y>Y</y>
+ * </MAGICID>
+ *
+ * with MAGICID = magicID(),
+ *         NAME = name(),
+ *            X = value().x(), and
+ *            Y = value().y().
  *
  * \param out The output device on which we serialize the parameter's state.
  */
-void PointFParameter::serialize(QIODevice& out) const
+void PointFParameter::serialize(QXmlStreamWriter& xmlWriter) const
 {
-    Parameter::serialize(out);
-    write_on_device(", "+ valueText(), out);
-}
+    xmlWriter.setAutoFormatting(true);
+    
+    xmlWriter.writeStartElement(magicID());
+    xmlWriter.writeTextElement("Name", name());
+    xmlWriter.writeTextElement("x", QString::number(value().x(),'g', 10));
+    xmlWriter.writeTextElement("y", QString::number(value().y(),'g', 10));
+    xmlWriter.writeEndElement();
 
+}
 /**
  * Deserialization of a parameter's state from an input device.
  *

--- a/src/core/parameters/pointfparameter.hxx
+++ b/src/core/parameters/pointfparameter.hxx
@@ -146,7 +146,7 @@ class GRAIPE_CORE_EXPORT PointFParameter
          *
          * \return The value of the parameter converted to an QString.
          */
-        QString valueText() const;
+        QString toString() const;
     
         /**
          * Serialization of the parameter's state to an output device.
@@ -173,7 +173,7 @@ class GRAIPE_CORE_EXPORT PointFParameter
          * \param in the input device.
          * \return True, if the deserialization was successful, else false.
          */
-        bool deserialize(QIODevice& in);
+        bool deserialize(QXmlStreamReader& xmlReader);
     
         /**
          * This function indicates whether the value of a parameter is valid or not.

--- a/src/core/parameters/pointfparameter.hxx
+++ b/src/core/parameters/pointfparameter.hxx
@@ -158,7 +158,7 @@ class GRAIPE_CORE_EXPORT PointFParameter
          *     <y>Y</y>
          * </MAGICID>
          *
-         * with MAGICID = magicID(),
+         * with MAGICID = typeName(),
          *         NAME = name(),
          *            X = value().x(), and
          *            Y = value().y().

--- a/src/core/parameters/pointfparameter.hxx
+++ b/src/core/parameters/pointfparameter.hxx
@@ -86,7 +86,7 @@ class GRAIPE_CORE_EXPORT PointFParameter
          *
          * \return "PointFParameter".
          */
-        QString typeName() const;
+        static QString typeName();
     
         /**
          * The lowest possible value of this parameter.

--- a/src/core/parameters/pointfparameter.hxx
+++ b/src/core/parameters/pointfparameter.hxx
@@ -147,14 +147,25 @@ class GRAIPE_CORE_EXPORT PointFParameter
          * \return The value of the parameter converted to an QString.
          */
         QString valueText() const;
-            
+    
         /**
          * Serialization of the parameter's state to an output device.
-         * Basically, it's just: "PointFParameter" + valueText()
+         * Writes the following XML on the device:
+         * 
+         * <MAGICID>
+         *     <Name>NAME</Name>
+         *     <x>X</x>
+         *     <y>Y</y>
+         * </MAGICID>
+         *
+         * with MAGICID = magicID(),
+         *         NAME = name(),
+         *            X = value().x(), and
+         *            Y = value().y().
          *
          * \param out The output device on which we serialize the parameter's state.
          */
-        void serialize(QIODevice& out) const;
+        void serialize(QXmlStreamWriter& xmlWriter) const;
     
         /**
          * Deserialization of a parameter's state from an input device.

--- a/src/core/parameters/pointfparameter.hxx
+++ b/src/core/parameters/pointfparameter.hxx
@@ -86,7 +86,7 @@ class GRAIPE_CORE_EXPORT PointFParameter
          *
          * \return "PointFParameter".
          */
-        static QString typeName();
+        virtual QString typeName() const;
     
         /**
          * The lowest possible value of this parameter.

--- a/src/core/parameters/pointfparameter.hxx
+++ b/src/core/parameters/pointfparameter.hxx
@@ -152,25 +152,25 @@ class GRAIPE_CORE_EXPORT PointFParameter
          * Serialization of the parameter's state to an output device.
          * Writes the following XML on the device:
          * 
-         * <MAGICID>
+         * <TYPENAME>
          *     <Name>NAME</Name>
          *     <x>X</x>
          *     <y>Y</y>
-         * </MAGICID>
+         * </TYPENAME>
          *
-         * with MAGICID = typeName(),
+         * with TYPENAME = typeName(),
          *         NAME = name(),
          *            X = value().x(), and
          *            Y = value().y().
          *
-         * \param out The output device on which we serialize the parameter's state.
+         * \param xmlWriter The QXmlStreamWriter on which we serialize the parameter's state.
          */
         void serialize(QXmlStreamWriter& xmlWriter) const;
     
         /**
-         * Deserialization of a parameter's state from an input device.
+         * Deserialization of a parameter's state from an xml file.
          *
-         * \param in the input device.
+         * \param xmlReader The QXmlStreamReader, where we read from.
          * \return True, if the deserialization was successful, else false.
          */
         bool deserialize(QXmlStreamReader& xmlReader);

--- a/src/core/parameters/pointparameter.cxx
+++ b/src/core/parameters/pointparameter.cxx
@@ -198,14 +198,31 @@ QString  PointParameter::valueText() const
 
 /**
  * Serialization of the parameter's state to an output device.
- * Basically, it's just: "PointParameter" + valueText()
+ * Writes the following XML on the device:
+ * 
+ * <MAGICID>
+ *     <Name>NAME</Name>
+ *     <x>X</x>
+ *     <y>Y</y>
+ * </MAGICID>
+ *
+ * with MAGICID = magicID(),
+ *         NAME = name(),
+ *            X = value().x(), and
+ *            Y = value().y().
  *
  * \param out The output device on which we serialize the parameter's state.
  */
-void PointParameter::serialize(QIODevice& out) const
+void PointParameter::serialize(QXmlStreamWriter& xmlWriter) const
 {
-    Parameter::serialize(out);
-    write_on_device(", "+ valueText(), out);
+    xmlWriter.setAutoFormatting(true);
+    
+    xmlWriter.writeStartElement(magicID());
+    xmlWriter.writeTextElement("Name", name());
+    xmlWriter.writeTextElement("x", QString::number(value().x()));
+    xmlWriter.writeTextElement("y", QString::number(value().y()));
+    xmlWriter.writeEndElement();
+
 }
 
 /**

--- a/src/core/parameters/pointparameter.cxx
+++ b/src/core/parameters/pointparameter.cxx
@@ -87,7 +87,7 @@ PointParameter::~PointParameter()
  *
  * \return "PointParameter".
  */
-QString  PointParameter::typeName() const
+QString  PointParameter::typeName()
 {
     return "PointParameter";
 }

--- a/src/core/parameters/pointparameter.cxx
+++ b/src/core/parameters/pointparameter.cxx
@@ -200,18 +200,18 @@ QString  PointParameter::toString() const
  * Serialization of the parameter's state to an output device.
  * Writes the following XML on the device:
  * 
- * <MAGICID>
+ * <TYPENAME>
  *     <Name>NAME</Name>
  *     <x>X</x>
  *     <y>Y</y>
- * </MAGICID>
+ * </TYPENAME>
  *
- * with MAGICID = typeName(),
+ * with TYPENAME = typeName(),
  *         NAME = name(),
  *            X = value().x(), and
  *            Y = value().y().
  *
- * \param out The output device on which we serialize the parameter's state.
+ * \param xmlWriter The QXmlStreamWriter on which we serialize the parameter's state.
  */
 void PointParameter::serialize(QXmlStreamWriter& xmlWriter) const
 {
@@ -226,9 +226,9 @@ void PointParameter::serialize(QXmlStreamWriter& xmlWriter) const
 }
 
 /**
- * Deserialization of a parameter's state from an input device.
+ * Deserialization of a parameter's state from an xml file.
  *
- * \param in the input device.
+ * \param xmlReader The QXmlStreamReader, where we read from.
  * \return True, if the deserialization was successful, else false.
  */
 bool PointParameter::deserialize(QXmlStreamReader& xmlReader)

--- a/src/core/parameters/pointparameter.cxx
+++ b/src/core/parameters/pointparameter.cxx
@@ -206,7 +206,7 @@ QString  PointParameter::toString() const
  *     <y>Y</y>
  * </MAGICID>
  *
- * with MAGICID = magicID(),
+ * with MAGICID = typeName(),
  *         NAME = name(),
  *            X = value().x(), and
  *            Y = value().y().
@@ -217,7 +217,7 @@ void PointParameter::serialize(QXmlStreamWriter& xmlWriter) const
 {
     xmlWriter.setAutoFormatting(true);
     
-    xmlWriter.writeStartElement(magicID());
+    xmlWriter.writeStartElement(typeName());
     xmlWriter.writeTextElement("Name", name());
     xmlWriter.writeTextElement("x", QString::number(value().x()));
     xmlWriter.writeTextElement("y", QString::number(value().y()));
@@ -237,7 +237,7 @@ bool PointParameter::deserialize(QXmlStreamReader& xmlReader)
     {
         if (xmlReader.readNextStartElement())
         {
-            if(xmlReader.name() == magicID())
+            if(xmlReader.name() == typeName())
             {
                 QPoint p;
                 
@@ -267,7 +267,7 @@ bool PointParameter::deserialize(QXmlStreamReader& xmlReader)
                         return false;
                     }
                     
-                    if(xmlReader.isEndElement() && xmlReader.name() == magicID())
+                    if(xmlReader.isEndElement() && xmlReader.name() == typeName())
                     {
                         break;
                     }
@@ -278,13 +278,13 @@ bool PointParameter::deserialize(QXmlStreamReader& xmlReader)
         }
         else
         {
-            throw std::runtime_error("Did not find magicID in XML tree");
+            throw std::runtime_error("Did not find typeName() in XML tree");
         }
         throw std::runtime_error("Did not find any start element in XML tree");
     }
     catch(std::runtime_error & e)
     {
-        qCritical() << "PointParameter::deserialize failed! Was looking for magicID: " << magicID() << "Error: " << e.what();
+        qCritical() << "PointParameter::deserialize failed! Was looking for typeName(): " << typeName() << "Error: " << e.what();
         return false;
     }
 }

--- a/src/core/parameters/pointparameter.cxx
+++ b/src/core/parameters/pointparameter.cxx
@@ -87,7 +87,7 @@ PointParameter::~PointParameter()
  *
  * \return "PointParameter".
  */
-QString  PointParameter::typeName()
+QString  PointParameter::typeName() const
 {
     return "PointParameter";
 }

--- a/src/core/parameters/pointparameter.cxx
+++ b/src/core/parameters/pointparameter.cxx
@@ -241,8 +241,10 @@ bool PointParameter::deserialize(QXmlStreamReader& xmlReader)
             {
                 QPoint p;
                 
-                while(xmlReader.readNextStartElement())
+                for(int i=0; i!=3; ++i)
                 {
+                    xmlReader.readNextStartElement();
+                    
                     if(xmlReader.name() == "Name")
                     {
                         setName(xmlReader.readElementText());
@@ -257,6 +259,19 @@ bool PointParameter::deserialize(QXmlStreamReader& xmlReader)
                     }
                 }
                 
+                //Read until </PointParameter> comes....
+                while(true)
+                {
+                    if(!xmlReader.readNext())
+                    {
+                        return false;
+                    }
+                    
+                    if(xmlReader.isEndElement() && xmlReader.name() == magicID())
+                    {
+                        break;
+                    }
+                }
                 setValue(p);
                 return true;
             }
@@ -303,12 +318,11 @@ QWidget*  PointParameter::delegate()
 
         m_spbXDelegate->setMaximumSize(9999,9999);
         m_spbXDelegate->setSizePolicy(QSizePolicy(QSizePolicy::Expanding,QSizePolicy::Expanding));
-    
-        m_spbYDelegate->setMaximumSize(9999,9999);
-        m_spbYDelegate->setSizePolicy(QSizePolicy(QSizePolicy::Expanding,QSizePolicy::Expanding));
-        
         m_spbXDelegate->setRange(m_min_value.x(), m_max_value.x());
         m_spbXDelegate->setValue(m_value.x());
+        
+        m_spbYDelegate->setMaximumSize(9999,9999);
+        m_spbYDelegate->setSizePolicy(QSizePolicy(QSizePolicy::Expanding,QSizePolicy::Expanding));
         m_spbYDelegate->setRange(m_min_value.y(), m_max_value.y());
         m_spbYDelegate->setValue(m_value.y());
         

--- a/src/core/parameters/pointparameter.cxx
+++ b/src/core/parameters/pointparameter.cxx
@@ -218,6 +218,7 @@ void PointParameter::serialize(QXmlStreamWriter& xmlWriter) const
     xmlWriter.setAutoFormatting(true);
     
     xmlWriter.writeStartElement(typeName());
+    xmlWriter.writeAttribute("ID", id());
     xmlWriter.writeTextElement("Name", name());
     xmlWriter.writeTextElement("x", QString::number(value().x()));
     xmlWriter.writeTextElement("y", QString::number(value().y()));
@@ -235,50 +236,50 @@ bool PointParameter::deserialize(QXmlStreamReader& xmlReader)
 {
     try
     {
-        if (xmlReader.readNextStartElement())
+        if(     xmlReader.name() == typeName()
+            &&  xmlReader.attributes().hasAttribute("ID"))
         {
-            if(xmlReader.name() == typeName())
+            setID(xmlReader.attributes().value("ID").toString());
+            
+            QPoint p;
+            
+            for(int i=0; i!=3; ++i)
             {
-                QPoint p;
+                xmlReader.readNextStartElement();
                 
-                for(int i=0; i!=3; ++i)
+                if(xmlReader.name() == "Name")
                 {
-                    xmlReader.readNextStartElement();
-                    
-                    if(xmlReader.name() == "Name")
-                    {
-                        setName(xmlReader.readElementText());
-                    }
-                    if(xmlReader.name() == "x")
-                    {
-                       p.setX(xmlReader.readElementText().toInt());
-                    }
-                    if(xmlReader.name() == "y")
-                    {
-                       p.setY(xmlReader.readElementText().toInt());
-                    }
+                    setName(xmlReader.readElementText());
                 }
-                
-                //Read until </PointParameter> comes....
-                while(true)
+                if(xmlReader.name() == "x")
                 {
-                    if(!xmlReader.readNext())
-                    {
-                        return false;
-                    }
-                    
-                    if(xmlReader.isEndElement() && xmlReader.name() == typeName())
-                    {
-                        break;
-                    }
+                   p.setX(xmlReader.readElementText().toInt());
                 }
-                setValue(p);
-                return true;
+                if(xmlReader.name() == "y")
+                {
+                   p.setY(xmlReader.readElementText().toInt());
+                }
             }
+            
+            //Read until </PointParameter> comes....
+            while(true)
+            {
+                if(!xmlReader.readNext())
+                {
+                    return false;
+                }
+                
+                if(xmlReader.isEndElement() && xmlReader.name() == typeName())
+                {
+                    break;
+                }
+            }
+            setValue(p);
+            return true;
         }
         else
         {
-            throw std::runtime_error("Did not find typeName() in XML tree");
+            throw std::runtime_error("Did not find typeName() or id() in XML tree");
         }
         throw std::runtime_error("Did not find any start element in XML tree");
     }

--- a/src/core/parameters/pointparameter.hxx
+++ b/src/core/parameters/pointparameter.hxx
@@ -147,7 +147,7 @@ class GRAIPE_CORE_EXPORT PointParameter
          *
          * \return The value of the parameter converted to an QString.
          */
-        QString valueText() const;
+        QString toString() const;
 
         /**
          * Serialization of the parameter's state to an output device.
@@ -174,7 +174,7 @@ class GRAIPE_CORE_EXPORT PointParameter
          * \param in the input device.
          * \return True, if the deserialization was successful, else false.
          */
-        bool deserialize(QIODevice& in);
+        bool deserialize(QXmlStreamReader& xmlReader);
     
         /**
          * This function indicates whether the value of a parameter is valid or not.

--- a/src/core/parameters/pointparameter.hxx
+++ b/src/core/parameters/pointparameter.hxx
@@ -87,7 +87,7 @@ class GRAIPE_CORE_EXPORT PointParameter
          *
          * \return "PointParameter".
          */
-        static QString typeName();
+        virtual QString typeName() const;
     
         /**
          * The lowest possible value of this parameter.

--- a/src/core/parameters/pointparameter.hxx
+++ b/src/core/parameters/pointparameter.hxx
@@ -87,7 +87,7 @@ class GRAIPE_CORE_EXPORT PointParameter
          *
          * \return "PointParameter".
          */
-        QString typeName() const;
+        static QString typeName();
     
         /**
          * The lowest possible value of this parameter.

--- a/src/core/parameters/pointparameter.hxx
+++ b/src/core/parameters/pointparameter.hxx
@@ -159,7 +159,7 @@ class GRAIPE_CORE_EXPORT PointParameter
          *     <y>Y</y>
          * </MAGICID>
          *
-         * with MAGICID = magicID(),
+         * with MAGICID = typeName(),
          *         NAME = name(),
          *            X = value().x(), and
          *            Y = value().y().

--- a/src/core/parameters/pointparameter.hxx
+++ b/src/core/parameters/pointparameter.hxx
@@ -153,25 +153,25 @@ class GRAIPE_CORE_EXPORT PointParameter
          * Serialization of the parameter's state to an output device.
          * Writes the following XML on the device:
          * 
-         * <MAGICID>
+         * <TYPENAME>
          *     <Name>NAME</Name>
          *     <x>X</x>
          *     <y>Y</y>
-         * </MAGICID>
+         * </TYPENAME>
          *
-         * with MAGICID = typeName(),
+         * with TYPENAME = typeName(),
          *         NAME = name(),
          *            X = value().x(), and
          *            Y = value().y().
          *
-         * \param out The output device on which we serialize the parameter's state.
+         * \param xmlWriter The QXmlStreamWriter on which we serialize the parameter's state.
          */
         void serialize(QXmlStreamWriter& xmlWriter) const;
     
         /**
-         * Deserialization of a parameter's state from an input device.
+         * Deserialization of a parameter's state from an xml file.
          *
-         * \param in the input device.
+         * \param xmlReader The QXmlStreamReader, where we read from.
          * \return True, if the deserialization was successful, else false.
          */
         bool deserialize(QXmlStreamReader& xmlReader);

--- a/src/core/parameters/pointparameter.hxx
+++ b/src/core/parameters/pointparameter.hxx
@@ -148,14 +148,25 @@ class GRAIPE_CORE_EXPORT PointParameter
          * \return The value of the parameter converted to an QString.
          */
         QString valueText() const;
-    
+
         /**
          * Serialization of the parameter's state to an output device.
-         * Basically, it's just: "PointParameter" + valueText()
+         * Writes the following XML on the device:
+         * 
+         * <MAGICID>
+         *     <Name>NAME</Name>
+         *     <x>X</x>
+         *     <y>Y</y>
+         * </MAGICID>
+         *
+         * with MAGICID = magicID(),
+         *         NAME = name(),
+         *            X = value().x(), and
+         *            Y = value().y().
          *
          * \param out The output device on which we serialize the parameter's state.
          */
-        void serialize(QIODevice& out) const;
+        void serialize(QXmlStreamWriter& xmlWriter) const;
     
         /**
          * Deserialization of a parameter's state from an input device.

--- a/src/core/parameters/stringparameter.cxx
+++ b/src/core/parameters/stringparameter.cxx
@@ -125,9 +125,10 @@ QString  StringParameter::toString() const
 }
 
 /**
- * Sets the value using a QString. This is the default method, used by the desearialize .
+ * Deserialization of a parameter's state from a string.
  *
- * \param str The value of the parameter converted to an QString
+ * \param str the input QString.
+ * \return True, if the deserialization was successful, else false.
  */
 bool StringParameter::fromString(QString& str)
 {

--- a/src/core/parameters/stringparameter.cxx
+++ b/src/core/parameters/stringparameter.cxx
@@ -62,7 +62,7 @@ StringParameter::StringParameter(const QString& name, const QString& value, unsi
 :   Parameter(name, parent, invert_parent),
     m_value(value),
     m_columns(columns),
-    m_lneDelegate(NULL)
+    m_delegate(NULL)
 {
 }
 
@@ -71,8 +71,8 @@ StringParameter::StringParameter(const QString& name, const QString& value, unsi
  */
 StringParameter::~StringParameter()
 {
-   if(m_lneDelegate != NULL)
-        delete m_lneDelegate;
+   if(m_delegate != NULL)
+        delete m_delegate;
 }
 
 /**
@@ -104,9 +104,9 @@ void StringParameter::setValue(const QString & value)
 {
     m_value = value;
     
-    if(m_lneDelegate != NULL)
+    if(m_delegate != NULL)
     {
-        m_lneDelegate->setText(value);
+        m_delegate->setText(value);
         Parameter::updateValue();
     }
 }
@@ -155,16 +155,16 @@ bool StringParameter::isValid() const
  */
 QWidget*  StringParameter::delegate()
 {
-    if(m_lneDelegate == NULL)
+    if(m_delegate == NULL)
     {
-        m_lneDelegate = new QLineEdit;
-        m_lneDelegate->setMinimumWidth(m_columns * m_lneDelegate->fontMetrics().width("X"));
-        m_lneDelegate->setText(value());
+        m_delegate = new QLineEdit;
+        m_delegate->setMinimumWidth(m_columns * m_delegate->fontMetrics().width("X"));
+        m_delegate->setText(value());
         
-        connect(m_lneDelegate, SIGNAL(textChanged(const QString&)), this, SLOT(updateValue()));
+        connect(m_delegate, SIGNAL(textChanged(const QString&)), this, SLOT(updateValue()));
         Parameter::initConnections();
     }
-    return m_lneDelegate;
+    return m_delegate;
 }
 
 
@@ -175,9 +175,9 @@ QWidget*  StringParameter::delegate()
 void StringParameter::updateValue()
 {
     //Should not happen - otherwise, better safe than sorry:
-    if(m_lneDelegate != NULL)
+    if(m_delegate != NULL)
     {
-        m_value = m_lneDelegate->text();
+        m_value = m_delegate->text();
         Parameter::updateValue();
     }
 }

--- a/src/core/parameters/stringparameter.cxx
+++ b/src/core/parameters/stringparameter.cxx
@@ -125,18 +125,6 @@ QString  StringParameter::valueText() const
 }
 
 /**
- * Serialization of the parameter's state to an output device.
- * Basically, it's just: "StringParameter" + encode_string(value())
- *
- * \param out The output device on which we serialize the parameter's state.
- */
-void StringParameter::serialize(QIODevice& out) const
-{
-    Parameter::serialize(out);
-    write_on_device(", " + encode_string(value()), out);
-}
-
-/**
  * Deserialization of a parameter's state from an input device.
  *
  * \param in the input device.

--- a/src/core/parameters/stringparameter.cxx
+++ b/src/core/parameters/stringparameter.cxx
@@ -80,7 +80,7 @@ StringParameter::~StringParameter()
  *
  * \return "StringParameter".
  */
-QString  StringParameter::typeName() const
+QString  StringParameter::typeName()
 {
 	return "StringParameter";
 }

--- a/src/core/parameters/stringparameter.cxx
+++ b/src/core/parameters/stringparameter.cxx
@@ -80,7 +80,7 @@ StringParameter::~StringParameter()
  *
  * \return "StringParameter".
  */
-QString  StringParameter::typeName()
+QString  StringParameter::typeName() const
 {
 	return "StringParameter";
 }

--- a/src/core/parameters/stringparameter.cxx
+++ b/src/core/parameters/stringparameter.cxx
@@ -119,28 +119,19 @@ void StringParameter::setValue(const QString & value)
  *
  * \return The value of the parameter converted to an QString.
  */
-QString  StringParameter::valueText() const
+QString  StringParameter::toString() const
 {
 	return value();
 }
 
 /**
- * Deserialization of a parameter's state from an input device.
+ * Sets the value using a QString. This is the default method, used by the desearialize .
  *
- * \param in the input device.
- * \return True, if the deserialization was successful, else false.
+ * \param str The value of the parameter converted to an QString
  */
-bool StringParameter::deserialize(QIODevice& in)
+bool StringParameter::fromString(QString& str)
 {
-    if(!Parameter::deserialize(in))
-    {
-        return false;
-    }
-    
-    QString content(in.readLine().trimmed());
-    
-    setValue(decode_string(content));
-    
+    setValue(str);
     return true;
 }
 

--- a/src/core/parameters/stringparameter.hxx
+++ b/src/core/parameters/stringparameter.hxx
@@ -88,7 +88,7 @@ class GRAIPE_CORE_EXPORT StringParameter
          *
          * \return "StringParameter".
          */
-        QString typeName() const;
+        static QString typeName();
         
         /** 
          * The current value of this parameter in the correct, most special type.

--- a/src/core/parameters/stringparameter.hxx
+++ b/src/core/parameters/stringparameter.hxx
@@ -104,15 +104,16 @@ class GRAIPE_CORE_EXPORT StringParameter
          */
         void setValue(const QString& value);
             
+            
         /**
          * The value converted to a QString. Please note, that this can vary from the 
          * serialize() result, which also returns a QString. This is due to the fact,
          * that serialize also may perform encoding of QStrings to avoid special chars
-         * inside the QString.
+         * inside the QString
          *
-         * \return The value of the parameter converted to an QString.
+         * \return The value of the parameter converted to an QString
          */
-        QString valueText() const;
+        QString toString() const;
     
         /**
          * Deserialization of a parameter's state from an input device.
@@ -120,7 +121,7 @@ class GRAIPE_CORE_EXPORT StringParameter
          * \param in the input device.
          * \return True, if the deserialization was successful, else false.
          */
-        bool deserialize(QIODevice& in);
+        bool fromString(QString& str);
     
         /**
          * This function indicates whether the value of a parameter is valid or not.

--- a/src/core/parameters/stringparameter.hxx
+++ b/src/core/parameters/stringparameter.hxx
@@ -88,7 +88,7 @@ class GRAIPE_CORE_EXPORT StringParameter
          *
          * \return "StringParameter".
          */
-        static QString typeName();
+        virtual QString typeName() const;
         
         /** 
          * The current value of this parameter in the correct, most special type.

--- a/src/core/parameters/stringparameter.hxx
+++ b/src/core/parameters/stringparameter.hxx
@@ -113,14 +113,6 @@ class GRAIPE_CORE_EXPORT StringParameter
          * \return The value of the parameter converted to an QString.
          */
         QString valueText() const;
-            
-        /**
-         * Serialization of the parameter's state to an output device.
-         * Basically, it's just: "StringParameter" + encode_string(value())
-         *
-         * \param out The output device on which we serialize the parameter's state.
-         */
-        void serialize(QIODevice& out) const;
     
         /**
          * Deserialization of a parameter's state from an input device.

--- a/src/core/parameters/stringparameter.hxx
+++ b/src/core/parameters/stringparameter.hxx
@@ -116,9 +116,9 @@ class GRAIPE_CORE_EXPORT StringParameter
         QString toString() const;
     
         /**
-         * Deserialization of a parameter's state from an input device.
+         * Deserialization of a parameter's state from a string.
          *
-         * \param in the input device.
+         * \param str the input QString.
          * \return True, if the deserialization was successful, else false.
          */
         bool fromString(QString& str);

--- a/src/core/parameters/stringparameter.hxx
+++ b/src/core/parameters/stringparameter.hxx
@@ -155,7 +155,7 @@ class GRAIPE_CORE_EXPORT StringParameter
         unsigned int m_columns;
     
         /** The delegate widget **/
-        QPointer<QLineEdit> m_lneDelegate;
+        QPointer<QLineEdit> m_delegate;
 };
 
 } //end of namespace graipe

--- a/src/core/parameters/transformparameter.cxx
+++ b/src/core/parameters/transformparameter.cxx
@@ -89,7 +89,7 @@ TransformParameter::~TransformParameter()
  *
  * \return "TransformParameter".
  */
-QString  TransformParameter::typeName() const
+QString  TransformParameter::typeName()
 {
     return "TransformParameter";
 }

--- a/src/core/parameters/transformparameter.cxx
+++ b/src/core/parameters/transformparameter.cxx
@@ -152,6 +152,7 @@ void TransformParameter::serialize(QXmlStreamWriter& xmlWriter) const
     xmlWriter.setAutoFormatting(true);
     
     xmlWriter.writeStartElement(typeName());
+    xmlWriter.writeAttribute("ID", id());
     xmlWriter.writeTextElement("Name", name());
         xmlWriter.writeStartElement("Transform");
         xmlWriter.writeAttribute("Type", "Affine");
@@ -178,55 +179,51 @@ bool TransformParameter::deserialize(QXmlStreamReader& xmlReader)
 {
     try
     {
-        if (xmlReader.readNextStartElement())
+        if(     xmlReader.name() == typeName()
+            &&  xmlReader.attributes().hasAttribute("ID"))
         {
-            if(xmlReader.name() == typeName())
-            {
-                for(int i=0; i!=2; ++i)
+            setID(xmlReader.attributes().value("ID").toString());
+            
+           for(int i=0; i!=2; ++i)
+           {
+                xmlReader.readNextStartElement();
+                
+                if(xmlReader.name() == "Name")
                 {
-                    xmlReader.readNextStartElement();
-                    
-                    if(xmlReader.name() == "Name")
-                    {
-                        setName(xmlReader.readElementText());
-                    }
-                    
-                    if(    xmlReader.name() == "Transform"
-                        && xmlReader.attributes().hasAttribute("Type")
-                        && xmlReader.attributes().value("Type") == "Affine")
-                    {
-                        double m11, m12, m13, m21, m22, m23, m31, m32, m33;
-                      
-                        for(int i=0; i!=9; ++i)
-                        {
-  
-                            xmlReader.readNextStartElement();
-                            
-                            if(xmlReader.name() == "m11") m11 = xmlReader.readElementText().toDouble();
-                            if(xmlReader.name() == "m12") m12 = xmlReader.readElementText().toDouble();
-                            if(xmlReader.name() == "m13") m13 = xmlReader.readElementText().toDouble();
-                            
-                            if(xmlReader.name() == "m21") m21 = xmlReader.readElementText().toDouble();
-                            if(xmlReader.name() == "m22") m22 = xmlReader.readElementText().toDouble();
-                            if(xmlReader.name() == "m23") m23 = xmlReader.readElementText().toDouble();
-                            
-                            if(xmlReader.name() == "m31") m31 = xmlReader.readElementText().toDouble();
-                            if(xmlReader.name() == "m32") m32 = xmlReader.readElementText().toDouble();
-                            if(xmlReader.name() == "m33") m33 = xmlReader.readElementText().toDouble();
-                        }
-                        setValue(QTransform(m11, m12, m13,    m21, m22, m23, m31, m32, m33));
-                        return true;
-                    }
+                    setName(xmlReader.readElementText());
                 }
-            }
-            else
-            {
-                throw std::runtime_error("Did not find typeName() in XML tree");
+                
+                if(    xmlReader.name() == "Transform"
+                    && xmlReader.attributes().hasAttribute("Type")
+                    && xmlReader.attributes().value("Type") == "Affine")
+                {
+                    double m11, m12, m13, m21, m22, m23, m31, m32, m33;
+                  
+                    for(int i=0; i!=9; ++i)
+                    {
+
+                        xmlReader.readNextStartElement();
+                        
+                        if(xmlReader.name() == "m11") m11 = xmlReader.readElementText().toDouble();
+                        if(xmlReader.name() == "m12") m12 = xmlReader.readElementText().toDouble();
+                        if(xmlReader.name() == "m13") m13 = xmlReader.readElementText().toDouble();
+                        
+                        if(xmlReader.name() == "m21") m21 = xmlReader.readElementText().toDouble();
+                        if(xmlReader.name() == "m22") m22 = xmlReader.readElementText().toDouble();
+                        if(xmlReader.name() == "m23") m23 = xmlReader.readElementText().toDouble();
+                        
+                        if(xmlReader.name() == "m31") m31 = xmlReader.readElementText().toDouble();
+                        if(xmlReader.name() == "m32") m32 = xmlReader.readElementText().toDouble();
+                        if(xmlReader.name() == "m33") m33 = xmlReader.readElementText().toDouble();
+                    }
+                    setValue(QTransform(m11, m12, m13,    m21, m22, m23, m31, m32, m33));
+                    return true;
+                }
             }
         }
         else
         {
-            throw std::runtime_error("Did not find any start element in XML tree");
+            throw std::runtime_error("Did not find typeName() or id() in XML tree");
         }
     }
     catch(std::runtime_error & e)

--- a/src/core/parameters/transformparameter.cxx
+++ b/src/core/parameters/transformparameter.cxx
@@ -123,79 +123,84 @@ void TransformParameter::setValue(const QTransform& value)
     }
 }
 
-/**
- * The value converted to a QString. Please note, that this can vary from the 
- * serialize() result, which also returns a QString. This is due to the fact,
- * that serialize also may perform encoding of QStrings to avoid special chars
- * inside the QString.
- *
- * \return The value of the parameter converted to an QString.
- */
-QString TransformParameter::valueText() const
+void TransformParameter::serialize(QXmlStreamWriter& xmlWriter) const
 {
-    return valueText(value());
+    xmlWriter.setAutoFormatting(true);
+    
+    xmlWriter.writeStartElement(magicID());
+    xmlWriter.writeTextElement("Name", name());
+        xmlWriter.writeStartElement("Transform");
+        xmlWriter.writeAttribute("Type", "Affine");
+            xmlWriter.writeTextElement("m11", QString::number(value().m11(), 'g', 10));
+            xmlWriter.writeTextElement("m12", QString::number(value().m12(), 'g', 10));
+            xmlWriter.writeTextElement("m13", QString::number(value().m13(), 'g', 10));
+            xmlWriter.writeTextElement("m21", QString::number(value().m21(), 'g', 10));
+            xmlWriter.writeTextElement("m22", QString::number(value().m22(), 'g', 10));
+            xmlWriter.writeTextElement("m23", QString::number(value().m23(), 'g', 10));
+            xmlWriter.writeTextElement("m31", QString::number(value().m31(), 'g', 10));
+            xmlWriter.writeTextElement("m32", QString::number(value().m32(), 'g', 10));
+            xmlWriter.writeTextElement("m33", QString::number(value().m33(), 'g', 10));
+        xmlWriter.writeEndElement();
+    xmlWriter.writeEndElement();
 }
-
-/**
- * Static function to convert a transformation into a list
- * of numbers with 10 digit precision. The order is as follows:
- * m11, m12, m13, m21, m22, m23, m31, m32, m33.
- *
- * \param trans The QTransform
- * \return A comma separated tring w.r.t. the order given above.
- */
-QString TransformParameter::valueText(const QTransform & trans)
-{
-
-    return   QString::number(trans.m11(), 'g', 10) + ", "
-           + QString::number(trans.m12(), 'g', 10) + ", "
-           + QString::number(trans.m13(), 'g', 10) + ", "
-           + QString::number(trans.m21(), 'g', 10) + ", "
-           + QString::number(trans.m22(), 'g', 10) + ", "
-           + QString::number(trans.m23(), 'g', 10) + ", "
-           + QString::number(trans.m31(), 'g', 10) + ", "
-           + QString::number(trans.m32(), 'g', 10) + ", "
-           + QString::number(trans.m33(), 'g', 10);
-}
-
 /**
  * Deserialization of a parameter's state from an input device.
  *
  * \param in the input device.
  * \return True, if the deserialization was successful, else false.
  */
-bool TransformParameter::deserialize(QIODevice& in)
+bool TransformParameter::deserialize(QXmlStreamReader& xmlReader)
 {
-    if(!Parameter::deserialize(in))
+    try
     {
+        if (xmlReader.readNextStartElement())
+        {
+            if(xmlReader.name() == magicID())
+            {
+                while(xmlReader.readNextStartElement())
+                {
+                    if(xmlReader.name() == "Name")
+                    {
+                        setName(xmlReader.readElementText());
+                    }
+                    if(    xmlReader.name() == "Transform"
+                        && xmlReader.attributes().hasAttribute("Type")
+                        && xmlReader.attributes().value("Type") == "Affine")
+                    {
+                        double m11, m12, m13, m21, m22, m23, m31, m32, m33;
+                        
+                        while(xmlReader.readNextStartElement())
+                        {
+                            
+                            if(xmlReader.name() == "m11") m11 = xmlReader.readElementText().toDouble();
+                            if(xmlReader.name() == "m12") m12 = xmlReader.readElementText().toDouble();
+                            if(xmlReader.name() == "m13") m13 = xmlReader.readElementText().toDouble();
+                            
+                            if(xmlReader.name() == "m21") m21 = xmlReader.readElementText().toDouble();
+                            if(xmlReader.name() == "m22") m22 = xmlReader.readElementText().toDouble();
+                            if(xmlReader.name() == "m23") m23 = xmlReader.readElementText().toDouble();
+                            
+                            if(xmlReader.name() == "m31") m31 = xmlReader.readElementText().toDouble();
+                            if(xmlReader.name() == "m32") m32 = xmlReader.readElementText().toDouble();
+                            if(xmlReader.name() == "m33") m33 = xmlReader.readElementText().toDouble();
+                        }
+                        setValue(QTransform(m11, m12, m13,    m21, m22, m23, m31, m32, m33));
+                        return true;
+                    }
+                }
+            }
+        }
+        else
+        {
+            throw std::runtime_error("Did not find magicID in XML tree");
+        }
+        throw std::runtime_error("Did not find any start element in XML tree");
+    }
+    catch(std::runtime_error & e)
+    {
+        qCritical() << "TransformParameter::deserialize failed! Was looking for magicID: " << magicID() << "Error: " << e.what();
         return false;
     }
-    
-    using namespace ::std;
-
-    QTransform trans;
-    
-    QString content(in.readLine().trimmed());
-    
-    QStringList values = content.split(", ");
-    
-    if(values.size() == 9)
-    {
-        try
-        {
-            trans.setMatrix(values[0].toDouble(), values[1].toDouble(), values[2].toDouble(),
-                            values[3].toDouble(), values[4].toDouble(), values[5].toDouble(),
-                            values[6].toDouble(), values[7].toDouble(), values[8].toDouble());
-            setValue(trans);
-            return true;
-        }
-        catch(...)
-        {
-        }
-    }
-    
-    qDebug("TransformParameter deserialize: date could not be imported from file using format 'dd.MM.yyyy hh:mm:ss'");
-    return false;
 }
 
 /**

--- a/src/core/parameters/transformparameter.cxx
+++ b/src/core/parameters/transformparameter.cxx
@@ -123,6 +123,30 @@ void TransformParameter::setValue(const QTransform& value)
     }
 }
 
+/**
+ * Serialization of the parameter's state to an output device.
+ * Writes the following XML on the device:
+ * 
+ * <TYPENAME>
+ *     <Name>NAME</Name>
+ *     <Transform Type="Affine">
+ *       <m11>value().m11()</m11>
+ *       <m12>value().m12()</m12>
+ *       <m13>value().m13()</m13>
+ *       <m21>value().m21()</m21>
+ *       <m22>value().m22()</m22>
+ *       <m23>value().m23()</m23>
+ *       <m31>value().m31()</m31>
+ *       <m32>value().m32()</m32>
+ *       <m33>value().m33()</m33>
+ *     </Transform>
+ * </TYPENAME>
+ *
+ * with TYPENAME = typeName(),
+ *         NAME = name().
+ *
+ * \param xmlWriter The QXmlStreamWriter on which we serialize the parameter's state.
+ */
 void TransformParameter::serialize(QXmlStreamWriter& xmlWriter) const
 {
     xmlWriter.setAutoFormatting(true);
@@ -143,10 +167,11 @@ void TransformParameter::serialize(QXmlStreamWriter& xmlWriter) const
         xmlWriter.writeEndElement();
     xmlWriter.writeEndElement();
 }
+
 /**
- * Deserialization of a parameter's state from an input device.
+ * Deserialization of a parameter's state from an xml file.
  *
- * \param in the input device.
+ * \param xmlReader The QXmlStreamReader, where we read from.
  * \return True, if the deserialization was successful, else false.
  */
 bool TransformParameter::deserialize(QXmlStreamReader& xmlReader)

--- a/src/core/parameters/transformparameter.cxx
+++ b/src/core/parameters/transformparameter.cxx
@@ -157,7 +157,7 @@ bool TransformParameter::deserialize(QXmlStreamReader& xmlReader)
         {
             if(xmlReader.name() == magicID())
             {
-                while(xmlReader.readNextStartElement())
+                for(int i=0; i!=2; ++i)
                 {
                     if(xmlReader.name() == "Name")
                     {
@@ -168,9 +168,11 @@ bool TransformParameter::deserialize(QXmlStreamReader& xmlReader)
                         && xmlReader.attributes().value("Type") == "Affine")
                     {
                         double m11, m12, m13, m21, m22, m23, m31, m32, m33;
-                        
-                        while(xmlReader.readNextStartElement())
+                      
+                        for(int i=0; i!=9; ++i)
                         {
+  
+                            xmlReader.readNextStartElement();
                             
                             if(xmlReader.name() == "m11") m11 = xmlReader.readElementText().toDouble();
                             if(xmlReader.name() == "m12") m12 = xmlReader.readElementText().toDouble();

--- a/src/core/parameters/transformparameter.cxx
+++ b/src/core/parameters/transformparameter.cxx
@@ -127,7 +127,7 @@ void TransformParameter::serialize(QXmlStreamWriter& xmlWriter) const
 {
     xmlWriter.setAutoFormatting(true);
     
-    xmlWriter.writeStartElement(magicID());
+    xmlWriter.writeStartElement(typeName());
     xmlWriter.writeTextElement("Name", name());
         xmlWriter.writeStartElement("Transform");
         xmlWriter.writeAttribute("Type", "Affine");
@@ -155,7 +155,7 @@ bool TransformParameter::deserialize(QXmlStreamReader& xmlReader)
     {
         if (xmlReader.readNextStartElement())
         {
-            if(xmlReader.name() == magicID())
+            if(xmlReader.name() == typeName())
             {
                 for(int i=0; i!=2; ++i)
                 {
@@ -194,13 +194,13 @@ bool TransformParameter::deserialize(QXmlStreamReader& xmlReader)
         }
         else
         {
-            throw std::runtime_error("Did not find magicID in XML tree");
+            throw std::runtime_error("Did not find typeName() in XML tree");
         }
         throw std::runtime_error("Did not find any start element in XML tree");
     }
     catch(std::runtime_error & e)
     {
-        qCritical() << "TransformParameter::deserialize failed! Was looking for magicID: " << magicID() << "Error: " << e.what();
+        qCritical() << "TransformParameter::deserialize failed! Was looking for typeName(): " << typeName() << "Error: " << e.what();
         return false;
     }
 }

--- a/src/core/parameters/transformparameter.cxx
+++ b/src/core/parameters/transformparameter.cxx
@@ -159,10 +159,13 @@ bool TransformParameter::deserialize(QXmlStreamReader& xmlReader)
             {
                 for(int i=0; i!=2; ++i)
                 {
+                    xmlReader.readNextStartElement();
+                    
                     if(xmlReader.name() == "Name")
                     {
                         setName(xmlReader.readElementText());
                     }
+                    
                     if(    xmlReader.name() == "Transform"
                         && xmlReader.attributes().hasAttribute("Type")
                         && xmlReader.attributes().value("Type") == "Affine")
@@ -191,18 +194,22 @@ bool TransformParameter::deserialize(QXmlStreamReader& xmlReader)
                     }
                 }
             }
+            else
+            {
+                throw std::runtime_error("Did not find typeName() in XML tree");
+            }
         }
         else
         {
-            throw std::runtime_error("Did not find typeName() in XML tree");
+            throw std::runtime_error("Did not find any start element in XML tree");
         }
-        throw std::runtime_error("Did not find any start element in XML tree");
     }
     catch(std::runtime_error & e)
     {
         qCritical() << "TransformParameter::deserialize failed! Was looking for typeName(): " << typeName() << "Error: " << e.what();
         return false;
     }
+    return false;
 }
 
 /**

--- a/src/core/parameters/transformparameter.cxx
+++ b/src/core/parameters/transformparameter.cxx
@@ -159,18 +159,6 @@ QString TransformParameter::valueText(const QTransform & trans)
 }
 
 /**
- * Serialization of the parameter's state to an output device.
- * Basically it's just: "TransformParameter, " + valueText()
- *
- * \param out The output device on which we serialize the parameter's state.
- */
-void TransformParameter::serialize(QIODevice& out) const
-{
-    Parameter::serialize(out);
-    write_on_device(", "+ valueText(), out);
-}
-
-/**
  * Deserialization of a parameter's state from an input device.
  *
  * \param in the input device.

--- a/src/core/parameters/transformparameter.cxx
+++ b/src/core/parameters/transformparameter.cxx
@@ -89,7 +89,7 @@ TransformParameter::~TransformParameter()
  *
  * \return "TransformParameter".
  */
-QString  TransformParameter::typeName()
+QString  TransformParameter::typeName() const
 {
     return "TransformParameter";
 }

--- a/src/core/parameters/transformparameter.hxx
+++ b/src/core/parameters/transformparameter.hxx
@@ -100,26 +100,32 @@ class GRAIPE_CORE_EXPORT TransformParameter
          * \param value The new value of this parameter.
          */
         void setValue(const QTransform& value);
-            
-        /**
-         * The value converted to a QString. Please note, that this can vary from the 
-         * serialize() result, which also returns a QString. This is due to the fact,
-         * that serialize also may perform encoding of QStrings to avoid special chars
-         * inside the QString.
-         *
-         * \return The value of the parameter converted to an QString.
-         */
-        QString valueText() const;
     
         /**
-         * Static function to convert a transformation into a list
-         * of numbers with 10 digit precision. The order is as follows:
-         * m11, m12, m13, m21, m22, m23, m31, m32, m33.
+         * Serialization of the parameter's state to an output device.
+         * Writes the following XML on the device:
+         * 
+         * <MAGICID>
+         *     <Name>NAME</Name>
+         *     <Transform Type="Affine">
+         *       <m11>value().m11()</m11>
+         *       <m12>value().m12()</m12>
+         *       <m13>value().m13()</m13>
+         *       <m21>value().m21()</m21>
+         *       <m22>value().m22()</m22>
+         *       <m23>value().m23()</m23>
+         *       <m31>value().m31()</m31>
+         *       <m32>value().m32()</m32>
+         *       <m33>value().m33()</m43>
+         *     </Transform>
+         * </MAGICID>
          *
-         * \param trans The QTransform
-         * \return A comma separated tring w.r.t. the order given above.
+         * with MAGICID = magicID(),
+         *         NAME = name().
+         *
+         * \param out The output device on which we serialize the parameter's state.
          */
-        static QString valueText(const QTransform& trans);
+        void serialize(QXmlStreamWriter& xmlWriter) const;
     
         /**
          * Deserialization of a parameter's state from an input device.
@@ -127,7 +133,7 @@ class GRAIPE_CORE_EXPORT TransformParameter
          * \param in the input device.
          * \return True, if the deserialization was successful, else false.
          */
-        bool deserialize(QIODevice& in);
+        bool deserialize(QXmlStreamReader& xmlReader);
     
         /**
          * This function indicates whether the value of a parameter is valid or not.

--- a/src/core/parameters/transformparameter.hxx
+++ b/src/core/parameters/transformparameter.hxx
@@ -85,7 +85,7 @@ class GRAIPE_CORE_EXPORT TransformParameter
          *
          * \return "TransformParameter".
          */
-        static QString typeName();
+        virtual QString typeName() const;
         
         /** 
          * The current value of this parameter in the correct, most special type.

--- a/src/core/parameters/transformparameter.hxx
+++ b/src/core/parameters/transformparameter.hxx
@@ -120,14 +120,6 @@ class GRAIPE_CORE_EXPORT TransformParameter
          * \return A comma separated tring w.r.t. the order given above.
          */
         static QString valueText(const QTransform& trans);
-
-        /**
-         * Serialization of the parameter's state to an output device.
-         * Basically it's just: "TransformParameter, " + valueText()
-         *
-         * \param out The output device on which we serialize the parameter's state.
-         */
-        void serialize(QIODevice& out) const;
     
         /**
          * Deserialization of a parameter's state from an input device.

--- a/src/core/parameters/transformparameter.hxx
+++ b/src/core/parameters/transformparameter.hxx
@@ -85,7 +85,7 @@ class GRAIPE_CORE_EXPORT TransformParameter
          *
          * \return "TransformParameter".
          */
-        QString typeName() const;
+        static QString typeName();
         
         /** 
          * The current value of this parameter in the correct, most special type.

--- a/src/core/parameters/transformparameter.hxx
+++ b/src/core/parameters/transformparameter.hxx
@@ -120,7 +120,7 @@ class GRAIPE_CORE_EXPORT TransformParameter
          *     </Transform>
          * </MAGICID>
          *
-         * with MAGICID = magicID(),
+         * with MAGICID = typeName(),
          *         NAME = name().
          *
          * \param out The output device on which we serialize the parameter's state.

--- a/src/core/parameters/transformparameter.hxx
+++ b/src/core/parameters/transformparameter.hxx
@@ -105,7 +105,7 @@ class GRAIPE_CORE_EXPORT TransformParameter
          * Serialization of the parameter's state to an output device.
          * Writes the following XML on the device:
          * 
-         * <MAGICID>
+         * <TYPENAME>
          *     <Name>NAME</Name>
          *     <Transform Type="Affine">
          *       <m11>value().m11()</m11>
@@ -116,21 +116,21 @@ class GRAIPE_CORE_EXPORT TransformParameter
          *       <m23>value().m23()</m23>
          *       <m31>value().m31()</m31>
          *       <m32>value().m32()</m32>
-         *       <m33>value().m33()</m43>
+         *       <m33>value().m33()</m33>
          *     </Transform>
-         * </MAGICID>
+         * </TYPENAME>
          *
-         * with MAGICID = typeName(),
+         * with TYPENAME = typeName(),
          *         NAME = name().
          *
-         * \param out The output device on which we serialize the parameter's state.
+         * \param xmlWriter The QXmlStreamWriter on which we serialize the parameter's state.
          */
         void serialize(QXmlStreamWriter& xmlWriter) const;
     
         /**
-         * Deserialization of a parameter's state from an input device.
+         * Deserialization of a parameter's state from an xml file.
          *
-         * \param in the input device.
+         * \param xmlReader The QXmlStreamReader, where we read from.
          * \return True, if the deserialization was successful, else false.
          */
         bool deserialize(QXmlStreamReader& xmlReader);

--- a/src/core/parameterselection.cxx
+++ b/src/core/parameterselection.cxx
@@ -115,9 +115,8 @@ ParameterSelection::~ParameterSelection()
  * 
  * \param parent      The parent widget, to make this selection modal.
  * \param model       The model, for which the selection shall be generated.
- * \param modelList The modelList of all models to copy the parameters from.
  */
-ModelParameterSelection::ModelParameterSelection(QWidget *parent, Model* model, const std::vector<Model*> * modelList)
+ModelParameterSelection::ModelParameterSelection(QWidget *parent, Model* model)
 :	QDialog(parent),
     m_radNewParameters(NULL),
     m_radCopyParameters(NULL),
@@ -145,7 +144,7 @@ ModelParameterSelection::ModelParameterSelection(QWidget *parent, Model* model, 
     connect(m_radNewParameters, SIGNAL(toggled(bool)), m_scrParameters, SLOT(setEnabled(bool)));
     connect(m_radCopyParameters, SIGNAL(toggled(bool)), m_scrParameters, SLOT(setDisabled(bool)));
     
-    m_otherModel = new ModelParameter("Model:", modelList, model->typeName());
+    m_otherModel = new ModelParameter("Model:", model->typeName());
     
     QHBoxLayout * layoutOtherModel = new QHBoxLayout(this);
     layoutOtherModel->addWidget(new QLabel(m_otherModel->name()));

--- a/src/core/parameterselection.hxx
+++ b/src/core/parameterselection.hxx
@@ -113,9 +113,8 @@ public:
      * 
      * \param parent      The parent widget, to make this selection modal.
      * \param model       The model, for which the selection shall be generated.
-     * \param modelList The modelList of all models to copy the parameters from.
      */
-    ModelParameterSelection(QWidget *parent, Model* model, const std::vector<Model*> * modelList);
+    ModelParameterSelection(QWidget *parent, Model* model);
 
     /**
      * Destructor of the parameter selection. This destructor returns the

--- a/src/core/qt_ext/qiocompressor.cxx
+++ b/src/core/qt_ext/qiocompressor.cxx
@@ -668,6 +668,18 @@ bool QIOCompressor::checkGzipSupport(const char * const versionString)
 
     return true;
 }
+qint64 QIOCompressor::pos() const //0 on the beginning, else: 1
+{
+    Q_D(const QIOCompressor);
+    if(d->state == QIOCompressorPrivate::NoBytesWritten)
+    {
+        return 0;
+    }
+    else
+    {
+        return 1;
+    }
+}
 
 }//end of namespace graipe
 

--- a/src/core/qt_ext/qiocompressor.hxx
+++ b/src/core/qt_ext/qiocompressor.hxx
@@ -120,6 +120,7 @@ public:
     void close();
     void flush();
     qint64 bytesAvailable() const;
+    qint64 pos() const; //0 on the beginning, else: 1
     
 protected:
     qint64 readData(char * data, qint64 maxSize);

--- a/src/core/serializable.cxx
+++ b/src/core/serializable.cxx
@@ -245,23 +245,23 @@ QString read_from_device_until(QIODevice& dev, const QString& str, bool one_line
 }
 
 /**
- * Getter for the filename of a serializable
+ * Getter for the id of a serializable
  *
- * \return the filename or an empty QString if none is assigned
+ * \return the id or an empty QString if none is assigned
  */
-QString Serializable::filename() const
+QString Serializable::id() const
 {
-    return m_filename;
+    return m_id;
 }
 
 /**
- * Setter for the filename of a serializable
+ * Setter for the id of a serializable
  *
- * \param new_filename  the new filename of this serializable
+ * \param new_id  the new id of this serializable
  */
-void Serializable::setFilename (const QString& new_filename)
+void Serializable::setID(const QString& new_id)
 {
-    m_filename = new_filename;
+    m_id = new_id;
 }
 
 /**

--- a/src/core/serializable.cxx
+++ b/src/core/serializable.cxx
@@ -155,7 +155,7 @@ void Serializable::setID(const QString& new_id)
  *
  * \return "Serializable" as a QString
  */
-QString Serializable::typeName() const
+QString Serializable::typeName()
 {
     return "Serializable";
 }

--- a/src/core/serializable.cxx
+++ b/src/core/serializable.cxx
@@ -155,7 +155,7 @@ void Serializable::setID(const QString& new_id)
  *
  * \return "Serializable" as a QString
  */
-QString Serializable::typeName()
+QString Serializable::typeName() const
 {
     return "Serializable";
 }

--- a/src/core/serializable.cxx
+++ b/src/core/serializable.cxx
@@ -36,8 +36,6 @@
 #include "core/serializable.hxx"
 #include "core/impex.hxx"
 
-#include <QUrl>
-
 /**
  * @file
  * @brief This file implements the needed serialization procedures.
@@ -47,20 +45,6 @@
  */
  
 namespace graipe {
-/**
- * Splits a string using a given separator.
- *
- * \param str the QString to be splitted
- * \param sep the separator, where we want to split
- *
- * \return If sep is found n times, a QStringList with n+1 items, each QString before the
- *         separator and each QString after the separator. If not found, the list
- *         just contains one element, namely the given string.
- */
-QStringList split_string(const QString & str, const QString & sep)
-{
-    return str.split(sep);
-}
 
 /**
  * Splits a string using a given separator on the first occurence only.
@@ -89,34 +73,6 @@ QStringList split_string_once(const QString & str, const QString & sep)
     }
     
     return result;
-}
-
-/**
- * Encodes a QString due to the HTML-Get encoding style. 
- * This is used to store QStrings in models' serializations to get 
- * rid of the newline and other problems.
- *
- * \param str the QString to be encoded
- *
- * \return the URL-encoded QString
- */
-QString encode_string(const QString & str)
-{
-    return QUrl::toPercentEncoding(str.toUtf8());
-}
-
-/**
- * Decodes a QString due to the HTML-Get decoding style.
- * This is used to restore QStrings from models' serializations to get
- * rid of the newline and other problems.
- *
- * \param str the URL-encoded QString
- *
- * \return the decoded string
- */
-QString decode_string(const QString & str)
-{
-    return QUrl::fromPercentEncoding(str.toUtf8());
 }
 
 /**
@@ -171,77 +127,6 @@ QDateTime qDateTimeFromSatelliteDateTime(const QString& str)
         return result;
     else
         return qDateTimeFromNumberDateTime(str);
-}
-
-
-/**
- * Writes a QString onto a QIODevice.
- * We wirte the characters by means of UTF8 encoding.
- *
- * \param str the QString, which shall be written.
- * \param dev the QIODevice, where we read from.
- */
-void write_on_device(const QString& str, QIODevice& dev)
-{
-    dev.write(str.toUtf8());
-}
-
-/**
- * Read a QString of a given length from a QIODevice.
- * We assume, that the QIODevice can read characters by means of UTF8.
- *
- * \param dev the QIODevice, where we read from.
- * \param len How many characters should being read?
- * 
- * \return the QString read from the stream
- */
-QString read_from_device(QIODevice& dev, int len)
-{
-    QByteArray arr = dev.read(len);
-    return QString::fromUtf8(arr);
-}
-
-/**
- * Reads from a QIODevice until a certain QString is found or one line is finished.
- * We assume, that the QIODevice can read characters by means of UTF8.
- *
- * \param dev the QIODevice, where we read from.
- * \param str the QString where we stop reading from the device
- * \param one_line If true, only one line is read at maximum.
- *
- * \return All characters read sofar (if the matching was successful, else ""
- */
-QString read_from_device_until(QIODevice& dev, const QString& str, bool one_line)
-{
-    int match_pos=0;
-    
-    QString sofar;
-    
-    while(!dev.atEnd() || match_pos == str.size())
-    {
-        QByteArray arr = dev.read(1);
-        QString current = QString::fromUtf8(arr);
-     
-        sofar += current;
-        
-        //break on lines
-        if (one_line && current == "\n")
-            return "";
-        
-        //current char matches next char to be found
-        if (current == str.at(match_pos))
-        {
-            match_pos++;
-        }
-        else
-        {
-            match_pos=0;
-        }
-        if(match_pos == str.size())
-            return sofar;
-    }
-    
-    return "";
 }
 
 /**

--- a/src/core/serializable.hxx
+++ b/src/core/serializable.hxx
@@ -219,15 +219,7 @@ class GRAIPE_CORE_EXPORT Serializable
          *
          * \return "Serializable" as a QString
          */
-        virtual QString typeName() const;
-    
-        /**
-         * Returns the unique magic id of a Serializable instance. 
-         * Has to be specialized in inheriting classes.
-         *
-         * \return The unique magicID.
-         */
-        virtual QString magicID() const = 0;
+        virtual QString typeName() const = 0;
     
         /**
          * Deserialization from an input device.

--- a/src/core/serializable.hxx
+++ b/src/core/serializable.hxx
@@ -148,7 +148,7 @@ class GRAIPE_CORE_EXPORT Serializable
          *
          * \return "Serializable" as a QString
          */
-        virtual QString typeName() const = 0;
+        static QString typeName();
     
         /**
          * Deserialization of a parameter's state from an xml file.

--- a/src/core/serializable.hxx
+++ b/src/core/serializable.hxx
@@ -167,7 +167,7 @@ class GRAIPE_CORE_EXPORT Serializable
         virtual void serialize(QXmlStreamWriter& xmlWriter) const = 0;
     
     protected:
-        /** the filename of this serializable instance **/
+        /** The id (sometimes used as a filename) of this serializable instance **/
         QString m_id;
 };
     

--- a/src/core/serializable.hxx
+++ b/src/core/serializable.hxx
@@ -200,18 +200,18 @@ class GRAIPE_CORE_EXPORT Serializable
 {
     public:
         /**
-         * Getter for the filename of a serializable
+         * Getter for the id of a serializable
          *
-         * \return the filename or an empty QString if none is assigned
+         * \return the id or an empty QString if none is assigned
          */
-        virtual QString filename() const;
+        virtual QString id() const;
     
         /**
-         * Setter for the filename of a serializable
+         * Setter for the id of a serializable
          *
-         * \param new_filename  the new filename of this serializable
+         * \param new_id  the new id of this serializable
          */
-        virtual void setFilename(const QString& new_filename);
+        virtual void setID(const QString& new_id);
     
         /**
          * Since we want to identify, we assign the Serializable class an uid.
@@ -240,7 +240,7 @@ class GRAIPE_CORE_EXPORT Serializable
     
     protected:
         /** the filename of this serializable instance **/
-        QString m_filename;
+        QString m_id;
 };
     
 }//end of namespace

--- a/src/core/serializable.hxx
+++ b/src/core/serializable.hxx
@@ -148,7 +148,7 @@ class GRAIPE_CORE_EXPORT Serializable
          *
          * \return "Serializable" as a QString
          */
-        static QString typeName();
+        virtual QString typeName() const;
     
         /**
          * Deserialization of a parameter's state from an xml file.

--- a/src/core/serializable.hxx
+++ b/src/core/serializable.hxx
@@ -44,6 +44,7 @@
 
 #include <QDateTime>
 #include <QIODevice>
+#include <QXmlStreamWriter>
 
 /**
  * @file
@@ -243,7 +244,7 @@ class GRAIPE_CORE_EXPORT Serializable
          *
          * \param out The output device.
          */
-        virtual void serialize(QIODevice& out) const = 0;
+        virtual void serialize(QXmlStreamWriter& xmlWriter) const = 0;
     
     protected:
         /** the filename of this serializable instance **/

--- a/src/core/serializable.hxx
+++ b/src/core/serializable.hxx
@@ -39,11 +39,7 @@
 #include "core/config.hxx"
 
 #include <QString>
-#include <vector>
-#include <map>
-
 #include <QDateTime>
-#include <QIODevice>
 #include <QXmlStreamWriter>
 
 /**
@@ -69,18 +65,6 @@
 namespace graipe {
 
 /**
- * Splits a string using a given separator.
- *
- * \param str the QString to be splitted
- * \param sep the separator, where we want to split
- *
- * \return If sep is found n times, a QStringList with n+1 items, each QString before the
- *         separator and each QString after the separator. If not found, the list
- *         just contains one element, namely the given string.
- */
-GRAIPE_CORE_EXPORT QStringList split_string(const QString & str, const QString & sep);
-
-/**
  * Splits a string using a given separator on the first occurence only.
  *
  * \param str the QString to be splitted
@@ -91,28 +75,6 @@ GRAIPE_CORE_EXPORT QStringList split_string(const QString & str, const QString &
  *         just contains one element, namely the given string.
  */
 GRAIPE_CORE_EXPORT QStringList split_string_once(const QString & str, const QString & sep);
-
-/**
- * Encodes a QString due to the HTML-Get encoding style. 
- * This is used to store QStrings in models' serializations to get 
- * rid of the newline and other problems.
- *
- * \param str the QString to be encoded
- *
- * \return the URL-encoded QString
- */
-GRAIPE_CORE_EXPORT QString encode_string(const QString & str);
-
-/**
- * Decodes a QString due to the HTML-Get decoding style.
- * This is used to restore QStrings from models' serializations to get
- * rid of the newline and other problems.
- *
- * \param str the URL-encoded QString
- *
- * \return the decoded string
- */
-GRAIPE_CORE_EXPORT QString decode_string(const QString & str);
 
 /**
  * Generate a qDateTime from a satellite_format QString.
@@ -145,39 +107,6 @@ GRAIPE_CORE_EXPORT QDateTime qDateTimeFromNumberDateTime(const QString& str);
  * \return QDateTime representation of this string. May be invalid, if conversion fails.
  */
 GRAIPE_CORE_EXPORT QDateTime qDateTimeFromSatelliteDateTime(const QString& str);
-
-/**
- * Writes a QString onto a QIODevice.
- * We wirte the characters by means of UTF8 encoding.
- *
- * \param str the QString, which shall be written.
- * \param dev the QIODevice, where we read from.
- */
-GRAIPE_CORE_EXPORT void write_on_device(const QString& str, QIODevice& dev);
-
-/**
- * Read a QString of a given length from a QIODevice.
- * We assume, that the QIODevice can read characters by means of UTF8.
- *
- * \param dev the QIODevice, where we read from.
- * \param len How many characters should being read?
- * 
- * \return the QString read from the stream
- */
-GRAIPE_CORE_EXPORT QString read_from_device(QIODevice& dev, int len);
-
-/**
- * Reads from a QIODevice until a certain QString is found or one line is finished.
- * We assume, that the QIODevice can read characters by means of UTF8.
- *
- * \param dev the QIODevice, where we read from.
- * \param str the QString where we stop reading from the device
- * \param one_line If true, only one line is read at maximum.
- *
- * \return All characters read sofar (if the matching was successful, else ""
- */
-GRAIPE_CORE_EXPORT QString read_from_device_until(QIODevice& dev, const QString& str, bool one_line=true);
-
 
 /**
  * The nearly pure interface of something that can be serialized
@@ -222,11 +151,10 @@ class GRAIPE_CORE_EXPORT Serializable
         virtual QString typeName() const = 0;
     
         /**
-         * Deserialization from an input device.
-         * Has to be specialized in inheriting classes.
+         * Deserialization of a parameter's state from an xml file.
          *
-         * \param in The input device.
-         * \return True, if the object could be successfully restored from the device.
+         * \param xmlReader The QXmlStreamReader, where we read from.
+         * \return True, if the deserialization was successful, else false.
          */
         virtual bool deserialize(QXmlStreamReader& xmlReader) = 0;
     
@@ -234,7 +162,7 @@ class GRAIPE_CORE_EXPORT Serializable
          * Serialization on to an output device.
          * Has to be specialized in inheriting classes.
          *
-         * \param out The output device.
+         * \param xmlWriter The QXmlStreamWriter on which we want to serialize.
          */
         virtual void serialize(QXmlStreamWriter& xmlWriter) const = 0;
     

--- a/src/core/serializable.hxx
+++ b/src/core/serializable.hxx
@@ -236,7 +236,7 @@ class GRAIPE_CORE_EXPORT Serializable
          * \param in The input device.
          * \return True, if the object could be successfully restored from the device.
          */
-        virtual bool deserialize(QIODevice& in) = 0;
+        virtual bool deserialize(QXmlStreamReader& xmlReader) = 0;
     
         /**
          * Serialization on to an output device.

--- a/src/core/viewcontroller.cxx
+++ b/src/core/viewcontroller.cxx
@@ -482,7 +482,7 @@ bool ViewController::deserialize(QXmlStreamReader& xmlReader)
             }
             else
             {
-                throw std::runtime_error("Did not find typeName() in XML tree");
+                throw std::runtime_error("Did not find typeName() or id() in XML tree");
             }
         //}
         //else

--- a/src/core/viewcontroller.cxx
+++ b/src/core/viewcontroller.cxx
@@ -408,7 +408,7 @@ void ViewController::updateParameters(bool /*force_update*/)
  *
  * \return "ViewController"
  */
-QString ViewController::typeName()
+QString ViewController::typeName() const
 {
     return "ViewController";
 }

--- a/src/core/viewcontroller.cxx
+++ b/src/core/viewcontroller.cxx
@@ -401,11 +401,6 @@ void ViewController::updateView()
  */
 void ViewController::updateParameters(bool /*force_update*/)
 {
-    if(m_model)
-    {
-       //TODO: Check if neccessary
-       //m_model_filename->setValue(m_model->filename());
-    }
 }
 
 /**
@@ -437,8 +432,8 @@ void ViewController::serialize(QXmlStreamWriter& xmlWriter) const
         xmlWriter.writeStartDocument();
      }
         xmlWriter.writeStartElement(typeName());
-        xmlWriter.writeAttribute("ID", filename());
-        xmlWriter.writeAttribute("ModelID", m_model->filename());
+        xmlWriter.writeAttribute("ID", id());
+        xmlWriter.writeAttribute("ModelID", m_model->id());
         xmlWriter.writeAttribute("ZOrder", QString::number(zValue()));
             m_parameters->serialize(xmlWriter);
         xmlWriter.writeEndElement();
@@ -467,7 +462,7 @@ bool ViewController::deserialize(QXmlStreamReader& xmlReader)
             if(     xmlReader.name() == typeName()
                 &&  xmlReader.attributes().hasAttribute("ID"))
             {
-                setFilename(xmlReader.attributes().value("ID").toString());
+                setID(xmlReader.attributes().value("ID").toString());
                 
                 bool success = m_parameters->deserialize(xmlReader);
                  

--- a/src/core/viewcontroller.cxx
+++ b/src/core/viewcontroller.cxx
@@ -431,10 +431,11 @@ QString ViewController::magicID() const
  *
  * \param out The output device, where we serialize to.
  */
-void ViewController::serialize(QIODevice& out) const
+void ViewController::serialize(QXmlStreamWriter& xmlWriter) const
 {
-	write_on_device(magicID() + "\n", out);
-    m_parameters->serialize(out);
+    //TODO!!!!
+	//write_on_device(magicID() + "\n", xmlWriter);
+    m_parameters->serialize(xmlWriter);
 }
 
 /**

--- a/src/core/viewcontroller.cxx
+++ b/src/core/viewcontroller.cxx
@@ -34,6 +34,9 @@
 /************************************************************************/
 
 #include "core/viewcontroller.hxx"
+#include "core/globals.hxx"
+
+#include <algorithm>
 
 #include <QPainter>
 #include <QGraphicsObject>
@@ -102,6 +105,9 @@ ViewController::ViewController(QGraphicsScene* scene, Model * model, int z_order
 	//connect other elements to update slot, too:
 	connect(m_parameters, SIGNAL(valueChanged()), this,	SLOT(updateView()));
 	connect(m_model,      SIGNAL(modelChanged()), this, SLOT(updateView()));
+    
+    //Add to global viewControllers list
+    viewControllers.push_back(this);
 }
 
 /**
@@ -111,6 +117,9 @@ ViewController::~ViewController()
 {
     this->scene()->removeItem(this);
     delete m_parameters;
+    
+    //Remove from global viewControllers list
+    viewControllers.erase(std::remove(viewControllers.begin(), viewControllers.end(), this), viewControllers.end());
 }
 
 /**
@@ -443,18 +452,22 @@ bool ViewController::deserialize(QXmlStreamReader& xmlReader)
 {
     try
     {
-        if (xmlReader.readNextStartElement())
-        {
+        //Assume, that the deserialized has already read the start node:
+        //if (xmlReader.readNextStartElement())
+        //{
             if(xmlReader.name() == typeName())
             {
                  return m_parameters->deserialize(xmlReader);
             }
-        }
-        else
-        {
-            throw std::runtime_error("Did not find typeName() in XML tree");
-        }
-        throw std::runtime_error("Did not find any start element in XML tree");
+            else
+            {
+                throw std::runtime_error("Did not find typeName() in XML tree");
+            }
+        //}
+        //else
+        //{
+        //  throw std::runtime_error("Did not find any start element in XML tree");
+        //}
     }
     catch(std::runtime_error & e)
     {

--- a/src/core/viewcontroller.cxx
+++ b/src/core/viewcontroller.cxx
@@ -86,8 +86,8 @@ ViewController::ViewController(QGraphicsScene* scene, Model * model, int z_order
     m_parameters->addParameter("name",m_name);
     m_parameters->addParameter("description",m_description);
     
-    m_model_filename->hide(true);
-    m_parameters->addParameter("modelFilename",m_model_filename);
+                                                                //Hidden
+    m_parameters->addParameter("modelFilename",m_model_filename, true);
     
     m_parameters->addParameter("showAx",m_showAxis);
     m_parameters->addParameter("axLineWidth", m_axisLineWidth);

--- a/src/core/viewcontroller.cxx
+++ b/src/core/viewcontroller.cxx
@@ -429,15 +429,23 @@ void ViewController::serialize(QXmlStreamWriter& xmlWriter) const
 {
     xmlWriter.setAutoFormatting(true);
     xmlWriter.setAutoFormattingIndent(4);
+        
+    bool fullFile = (xmlWriter.device()->pos() == 0);
     
-    xmlWriter.writeStartDocument();
+    if (fullFile)
+    {
+        xmlWriter.writeStartDocument();
+     }
         xmlWriter.writeStartElement(typeName());
         xmlWriter.writeAttribute("ModelID", m_model->filename());
         xmlWriter.writeAttribute("ZOrder", QString::number(zValue()));
-    
             m_parameters->serialize(xmlWriter);
         xmlWriter.writeEndElement();
-    xmlWriter.writeEndDocument();
+    
+    if (fullFile)
+    {
+        xmlWriter.writeEndDocument();
+     }
 }
 
 /**

--- a/src/core/viewcontroller.cxx
+++ b/src/core/viewcontroller.cxx
@@ -408,7 +408,7 @@ void ViewController::updateParameters(bool /*force_update*/)
  *
  * \return "ViewController"
  */
-QString ViewController::typeName() const
+QString ViewController::typeName()
 {
     return "ViewController";
 }

--- a/src/core/viewcontroller.hxx
+++ b/src/core/viewcontroller.hxx
@@ -212,7 +212,7 @@ class GRAIPE_CORE_EXPORT ViewController
          *
          * \return "ViewController"
          */
-        QString typeName() const;
+        static QString typeName();
     
         /**
          * This function serializes a complete ViewController to an output device.

--- a/src/core/viewcontroller.hxx
+++ b/src/core/viewcontroller.hxx
@@ -212,7 +212,7 @@ class GRAIPE_CORE_EXPORT ViewController
          *
          * \return "ViewController"
          */
-        static QString typeName();
+        virtual QString typeName() const;
     
         /**
          * This function serializes a complete ViewController to an output device.

--- a/src/core/viewcontroller.hxx
+++ b/src/core/viewcontroller.hxx
@@ -213,18 +213,10 @@ class GRAIPE_CORE_EXPORT ViewController
          * \return "ViewController"
          */
         QString typeName() const;
-
-        /**
-         * This function returns the automagically generated first header line for ViewController
-         * serialization.
-         *
-         * \return The first Header line, namely: "[Graipe::" + typeName() + "]"
-         */
-        QString magicID() const;
     
         /**
          * This function serializes a complete ViewController to an output device.
-         * To do so, it serializes the magicID(), then the model denoted by the model's
+         * To do so, it serializes the typeName(), then the model denoted by the model's
          * filename and eventually the parameter set.
          *
          * \param out The output device, where we serialize to.
@@ -261,7 +253,6 @@ class GRAIPE_CORE_EXPORT ViewController
         //The view's parameter
         StringParameter *m_name;
         LongStringParameter *m_description;
-        LongStringParameter *m_model_filename;
     
         BoolParameter	*m_showAxis;
         FloatParameter	*m_axisLineWidth;

--- a/src/core/viewcontroller.hxx
+++ b/src/core/viewcontroller.hxx
@@ -239,7 +239,7 @@ class GRAIPE_CORE_EXPORT ViewController
          * \param  in The input device, where we read the serialization of this ViewController class from.
          * \return True, if the parameters could be restored,
          */
-        bool deserialize(QIODevice& in);
+        bool deserialize(QXmlStreamReader& xmlReader);
     
     public slots:
         /**

--- a/src/core/viewcontroller.hxx
+++ b/src/core/viewcontroller.hxx
@@ -229,7 +229,7 @@ class GRAIPE_CORE_EXPORT ViewController
          *
          * \param out The output device, where we serialize to.
          */
-        void serialize(QIODevice& out) const;
+        void serialize(QXmlStreamWriter& xmlWriter) const;
     
         /**
          * This function deserializes the ViewController by means of its parameter settings.

--- a/src/gui/main.cpp
+++ b/src/gui/main.cpp
@@ -50,12 +50,11 @@
 int main(int argc, char** argv)
 {    
     //Install thes logger's message handler
-    //TODO: GET IT WORKING
-    //qInstallMessageHandler(&graipe::Logging::messageHandler);
+    qInstallMessageHandler(&graipe::Logging::messageHandler);
     
     QApplication app(argc,argv);
 
-    graipe::MainWindow m(0,"GRAIPE 1.2");
+    graipe::MainWindow m(0,"GRAIPE 1.0");
 	
     if (	QApplication::desktop()->width() > m.width() + 50
 		 && QApplication::desktop()->height() > m.height() + 50 )

--- a/src/gui/main.cpp
+++ b/src/gui/main.cpp
@@ -50,7 +50,8 @@
 int main(int argc, char** argv)
 {    
     //Install thes logger's message handler
-    qInstallMessageHandler(&graipe::Logging::messageHandler);
+    //TODO: GET IT WORKING
+    //qInstallMessageHandler(&graipe::Logging::messageHandler);
     
     QApplication app(argc,argv);
 

--- a/src/gui/mainwindow.cxx
+++ b/src/gui/mainwindow.cxx
@@ -486,21 +486,6 @@ void MainWindow::runAlgorithm(int index)
 	Algorithm* alg = alg_item.algorithm_fptr();
 	alg->setGlobalAlgorithmMutex(&global_algorithm_mutex);
     
-	//Create temporary model list for algorithm
-	vector<Model*>* alg_object_stack = new vector<Model*>;
-
-	for(int i=0; i!=m_ui.listModels->count(); i++)
-	{
-		QListWidgetModelItem * model_item = dynamic_cast<QListWidgetModelItem *>(m_ui.listModels->item(i));
-		if (model_item && model_item->model() ) 
-		{
-			alg_object_stack->push_back( model_item->model() );
-		}
-	}
-	
-	//Refresh object stack for all params
-	alg->parameters()->refresh();
-    
 	AlgorithmParameterSelection parameter_selection(this, alg);
 	parameter_selection.setWindowTitle(alg_item.algorithm_name);
 	parameter_selection.setModal(true);
@@ -538,10 +523,6 @@ void MainWindow::runAlgorithm(int index)
 			
 		}
 	}
-	
-	//After all, we can erase the temporary model stack:
-	delete alg_object_stack;
-	alg_object_stack = NULL;
 }
 
 

--- a/src/gui/mainwindow.cxx
+++ b/src/gui/mainwindow.cxx
@@ -523,6 +523,15 @@ void MainWindow::runAlgorithm(int index)
 			
 		}
 	}
+    else
+    {
+        for(Model* m : alg->results())
+        {
+            delete m;
+            m=NULL;
+        }
+        alg->results().clear();
+    }
 }
 
 
@@ -1356,7 +1365,7 @@ void MainWindow::updateStatusDescription(QString str)
  */
 void MainWindow::updateMemoryUsage()
 {
-    m_lblMemoryUsage->setText(QString("(Memory: %1 MB, max: %2 MB)").arg((float)(getCurrentRSS()>>10)/1024).arg((float)(getPeakRSS()>>10)/1024));
+    m_lblMemoryUsage->setText(QString("%1 Models, %2 Views (Memory: %3 MB, max: %4 MB)").arg(models.size()).arg(viewControllers.size()).arg((float)(getCurrentRSS()>>10)/1024).arg((float)(getPeakRSS()>>10)/1024));
 }
 
 /**

--- a/src/gui/mainwindow.cxx
+++ b/src/gui/mainwindow.cxx
@@ -253,7 +253,7 @@ void MainWindow::reset()
  */
 void MainWindow::loadModel()
 {	
-	QFileDialog dialog(this, "Load models", m_default_dir, "GRAIPE models (*.gz *.csv)");
+	QFileDialog dialog(this, "Load models", m_default_dir, "GRAIPE models (*.xgz *.xml)");
 	dialog.setFileMode(QFileDialog::ExistingFiles);
 	dialog.setViewMode(QFileDialog::Detail);
 	
@@ -784,7 +784,7 @@ void MainWindow::saveCurrentModel()
 		QString suggested_filename = model->name().replace(" ", "_");
 		QString filename = QFileDialog::getSaveFileName(this, tr("Save Model to file"),
                            suggested_filename,
-                            tr("Packed GRAIPE-models (*.gz);;Unpacked GRAIPE-models (*.csv)"));
+                            tr("Packed GRAIPE-models (*.xgz);;Unpacked GRAIPE-models (*.xml)"));
 		
 		if(!filename.isEmpty())
 		{	
@@ -973,7 +973,7 @@ void MainWindow::saveWorkspace(const QString& dirname)
                 if(model_item && model_item->model())
                 {
                     Model* model = model_item->model();
-                    QString suggested_filename = QString("model_%1.csv.gz").arg(j);
+                    QString suggested_filename = QString("model_%1.xgz").arg(j);
                     QString model_filename = dir.filePath(suggested_filename);
                     
                     if(!Impex::save(model, model_filename, true))
@@ -1001,7 +1001,7 @@ void MainWindow::saveWorkspace(const QString& dirname)
                 {
                     ViewController* viewController = vc_item->viewController();
                     
-                    QString suggested_filename = QString("viewController_%1.csv.gz").arg(i);
+                    QString suggested_filename = QString("viewController_%1.xgz").arg(i);
                     
                     if(!Impex::save(viewController, dir.filePath(suggested_filename), true))
                     {

--- a/src/gui/mainwindow.cxx
+++ b/src/gui/mainwindow.cxx
@@ -937,11 +937,11 @@ void MainWindow::saveWorkspace(const QString& xmlFilename)
                 if(model_item && model_item->model())
                 {
                     Model* model = model_item->model();
-                    model->setFilename(xmlFilename + QString("/model%1").arg(i));
+                    model->setID(xmlFilename + QString("/model%1").arg(i));
                     
                     if(model == currentModel())
                     {
-                        currentModelID = model->filename();
+                        currentModelID = model->id();
                     }
                 }
             }
@@ -955,15 +955,15 @@ void MainWindow::saveWorkspace(const QString& xmlFilename)
                 {
                     ViewController* vc = vc_item->viewController();
                 
-                    vc->setFilename(xmlFilename + QString("/viewController%1").arg(i));
+                    vc->setID(xmlFilename + QString("/viewController%1").arg(i));
                 
                     if(vc == currentViewController())
                     {
-                        currentViewControllerID = vc->filename();
+                        currentViewControllerID = vc->id();
                     }
                     if(vc_item->checkState() == Qt::CheckState::Checked)
                     {
-                        visibleViewControllerIDs.append(vc->filename());
+                        visibleViewControllerIDs.append(vc->id());
                     }
                 }
             }
@@ -1147,7 +1147,7 @@ void MainWindow::restoreWorkspace(const QString& xmlFilename)
                                             if(m != NULL)
                                             {
                                                 addModelItemToList(m);
-                                                if(m->filename() == p_currentModel->value())
+                                                if(m->id() == p_currentModel->value())
                                                 {
                                                     m_ui.listModels->setCurrentRow(m_ui.listModels->count()-1);
                                                 }
@@ -1180,12 +1180,12 @@ void MainWindow::restoreWorkspace(const QString& xmlFilename)
                                                     {
                                                         addViewControllerItemToList(vc);
                                                         
-                                                        if(vc->filename() == p_currentVC->value())
+                                                        if(vc->id() == p_currentVC->value())
                                                         {
                                                             m_ui.listViews->setCurrentRow(m_ui.listViews->count()-1);
                                                         }
                                                         Qt::CheckState state = Qt::CheckState::Unchecked;
-                                                        if(activeVCs.contains(vc->filename()))
+                                                        if(activeVCs.contains(vc->id()))
                                                         {
                                                             state = Qt::CheckState::Checked;
                                                         }

--- a/src/gui/mainwindow.cxx
+++ b/src/gui/mainwindow.cxx
@@ -162,6 +162,13 @@ MainWindow::MainWindow(QWidget* parent, const char* name, Qt::WindowFlags f) :
     
     this->setWindowTitle("GRAIPE v." + version_name);
     
+    //Set Stylesheet for info label:
+    m_ui.lblStatusInformation->setStyleSheet(
+        QString("QLabel table {     width: 100%;   border: 1px solid black; } ")
+            + "QLabel th {  padding: 5px;     border: 1px solid black; } "
+            + "QLabel td {  text-align: right; padding: 5px; border: 1px solid black; } "
+        );
+    
     //load the recent files from the "graipe.ini" file
     updateRecentActionList();
     

--- a/src/gui/mainwindow.cxx
+++ b/src/gui/mainwindow.cxx
@@ -1175,6 +1175,7 @@ void MainWindow::loadViewController(const QString& filename)
     ViewController* viewController = NULL;
     bool compress =  (filename.right(2) == "gz");
     
+    //TODO: Does not work! Imagine better way to solve impex for ViewControllers!
     std::map<QString,QString> dict = Impex::dictFromFile(filename, compress);
     
     //1. read out the Type of the view and find him in the vc_factory

--- a/src/gui/mainwindow.hxx
+++ b/src/gui/mainwindow.hxx
@@ -415,15 +415,6 @@ private:
 
     //a printer (of the view)
     QPrinter* m_printer;
-    
-    //model/model-controller factory
-    ModelFactory m_model_factory;
-
-    //model/view/controller factory
-    ViewControllerFactory m_viewController_factory;
-
-    //algorithms factory
-    AlgorithmFactory m_algorithm_factory;
 
     //signal mapping for dynamically loaded algorithms (and their dynamically created actions)
     QSignalMapper* m_signalMapper;
@@ -445,7 +436,6 @@ private:
     
     QList<QAction*> m_recentFileActions;
     const int       m_recentFileCount;
-    
 };
 
 } //end of namespace graipe

--- a/src/modules/analysis/analysismodule.cxx
+++ b/src/modules/analysis/analysismodule.cxx
@@ -118,7 +118,7 @@ class MeanVectorfield
                         
                         //Copy all metadata from current image (will be overwritten later)
                         vf->copyMetadata(*new_vf);
-                        new_vf->setName(QString("mean vectorfield of ") + param_vectorfields->valueText());
+                        new_vf->setName(QString("mean vectorfield of ") + param_vectorfields->toString());
                                         
                         m_results.push_back(new_vf);
                         
@@ -574,7 +574,7 @@ class Vectorfield2DCurl
                     
                     img->setBand(0,res);
                     img->setName("Scalar Curl of: " + vf->name());
-                    img->setDescription("A gaussian sigma of: " + param_sigma->valueText() + " has been used to derive the gradents of the vectorfield.");
+                    img->setDescription("A gaussian sigma of: " + param_sigma->toString() + " has been used to derive the gradents of the vectorfield.");
                     
                     m_results.push_back(img);
                     
@@ -672,7 +672,7 @@ class Vectorfield2DDiv
                     
                     img->setBand(0,res);
                     img->setName("Divergence of: " + vf->name());
-                    img->setDescription("A gaussian sigma of: " + param_sigma->valueText() + " has been used to derive the gradents of the vectorfield.");
+                    img->setDescription("A gaussian sigma of: " + param_sigma->toString() + " has been used to derive the gradents of the vectorfield.");
                     
                     m_results.push_back(img);
                     

--- a/src/modules/analysis/analysismodule.cxx
+++ b/src/modules/analysis/analysismodule.cxx
@@ -55,7 +55,7 @@ class MeanVectorfield
          */
         MeanVectorfield()
         {
-            m_parameters->addParameter("vf", new MultiModelParameter("(Dense) Vectorfields",	NULL,  "DenseVectorfield2D"));
+            m_parameters->addParameter("vf", new MultiModelParameter("(Dense) Vectorfields",  "DenseVectorfield2D"));
         }
         
         /**
@@ -164,8 +164,8 @@ class Vectorfield2DDenseModelComparison
          */
         Vectorfield2DDenseModelComparison()
         {
-            m_parameters->addParameter("vf1", new ModelParameter("Derived Vectorfield",	NULL,  "SparseVectorfield2D | SparseWeightedVectorfield2D | SparseMultiVectorfield2D | SparseWeightedMultiVectorfield2D | DenseVectorfield2D | DenseWeightedVectorfield2D"));
-            m_parameters->addParameter("vf2", new ModelParameter("Reference Vectorfield to compare with",	NULL,  "DenseVectorfield2D | DenseWeightedVectorfield2D"));
+            m_parameters->addParameter("vf1", new ModelParameter("Derived Vectorfield",	"SparseVectorfield2D | SparseWeightedVectorfield2D | SparseMultiVectorfield2D | SparseWeightedMultiVectorfield2D | DenseVectorfield2D | DenseWeightedVectorfield2D"));
+            m_parameters->addParameter("vf2", new ModelParameter("Reference Vectorfield to compare with", "DenseVectorfield2D | DenseWeightedVectorfield2D"));
             m_parameters->addParameter("degree", new IntParameter("Use spline interpolation of degree", 0, 5,1));
         }
 	
@@ -317,8 +317,8 @@ class Vectorfield2DGenericComparison
          */
         Vectorfield2DGenericComparison()
         {
-            m_parameters->addParameter("vf1", new ModelParameter("First Vectorfield",	NULL,  "SparseVectorfield2D | SparseWeightedVectorfield2D | SparseMultiVectorfield2D | SparseWeightedMultiVectorfield2D | DenseVectorfield2D | DenseWeightedVectorfield2D"));
-            m_parameters->addParameter("vf2", new ModelParameter("Reference Vectorfield to compare with",	NULL,  "SparseVectorfield2D | SparseWeightedVectorfield2D | SparseMultiVectorfield2D | SparseWeightedMultiVectorfield2D | DenseVectorfield2D | DenseWeightedVectorfield2D"));
+            m_parameters->addParameter("vf1", new ModelParameter("First Vectorfield", "SparseVectorfield2D | SparseWeightedVectorfield2D | SparseMultiVectorfield2D | SparseWeightedMultiVectorfield2D | DenseVectorfield2D | DenseWeightedVectorfield2D"));
+            m_parameters->addParameter("vf2", new ModelParameter("Reference Vectorfield to compare with",  "SparseVectorfield2D | SparseWeightedVectorfield2D | SparseMultiVectorfield2D | SparseWeightedMultiVectorfield2D | DenseVectorfield2D | DenseWeightedVectorfield2D"));
             m_parameters->addParameter("n", new IntParameter("use n nearest neighbors in reference vf", 0, 100));
         }
         
@@ -425,7 +425,7 @@ class Vectorfield2DSeparation
          */
         Vectorfield2DSeparation()
         {
-            m_parameters->addParameter("vf", new ModelParameter("Vectorfield",	NULL,  "SparseVectorfield2D | SparseWeightedVectorfield2D | SparseMultiVectorfield2D | SparseWeightedMultiVectorfield2D | DenseVectorfield2D | DenseWeightedVectorfield2D"));
+            m_parameters->addParameter("vf", new ModelParameter("Vectorfield", "SparseVectorfield2D | SparseWeightedVectorfield2D | SparseMultiVectorfield2D | SparseWeightedMultiVectorfield2D | DenseVectorfield2D | DenseWeightedVectorfield2D"));
         }
         
         /**
@@ -522,7 +522,7 @@ class Vectorfield2DCurl
          */
         Vectorfield2DCurl()
         {
-            m_parameters->addParameter("vf", new ModelParameter("Vectorfield",	NULL,  "DenseVectorfield2D | DenseWeightedVectorfield2D"));
+            m_parameters->addParameter("vf", new ModelParameter("Vectorfield", "DenseVectorfield2D | DenseWeightedVectorfield2D"));
             m_parameters->addParameter("sigma", new FloatParameter("Sigma for gaussian gradient:",	0.5, 100, 1));
         }
         
@@ -620,7 +620,7 @@ class Vectorfield2DDiv
          */
         Vectorfield2DDiv()
         {
-            m_parameters->addParameter("vf", new ModelParameter("Vectorfield",	NULL,  "DenseVectorfield2D | DenseWeightedVectorfield2D"));
+            m_parameters->addParameter("vf", new ModelParameter("Vectorfield", "DenseVectorfield2D | DenseWeightedVectorfield2D"));
             m_parameters->addParameter("sigma", new FloatParameter("Sigma for gaussian gradient:",	0.5, 100, 1));
         }
         

--- a/src/modules/analysis/vectorfieldseparation.hxx
+++ b/src/modules/analysis/vectorfieldseparation.hxx
@@ -98,7 +98,8 @@ VECTORFIELD_CLASS* computeGlobalMotionOfVectorfield(const VECTORFIELD_CLASS* vf)
                          mat(0,1), mat(1,1), mat(2,1),
                          mat(0,2), mat(1,2), mat(2,2));
 
-    QString mat_str = TransformParameter::valueText(transform);
+    QString mat_str = "";
+        //TODO:TransformParameter::valueText(transform);
     
 	result_vf->setGlobalMotion(transform);
 	result_vf->setName(QString("Separated motion of: ") + vf->name());
@@ -107,7 +108,7 @@ VECTORFIELD_CLASS* computeGlobalMotionOfVectorfield(const VECTORFIELD_CLASS* vf)
 	
 	ss  << "Separated motion of: " <<  vf->name() << "\n"
 		<< "Matrix was:\n"
-		<< mat_str;
+        << mat_str;
 	
 	result_vf->setDescription(ss.readAll());
 							  

--- a/src/modules/featuredetection/featuredetectionmodule.cxx
+++ b/src/modules/featuredetection/featuredetectionmodule.cxx
@@ -369,7 +369,7 @@ class CannyFeatureLengthFilter
          */
         CannyFeatureLengthFilter()
         {
-            m_parameters->addParameter("edgels",     new ModelParameter("Edgel Featurelist (2D)", NULL, "EdgelFeatureList2D"));
+            m_parameters->addParameter("edgels",     new ModelParameter("Edgel Featurelist (2D)", "EdgelFeatureList2D"));
             m_parameters->addParameter("min-length", new FloatParameter("Minimal Edgel length", 0,9999999, 0));
             m_parameters->addParameter("radius",     new FloatParameter("Search radius for Edgel-unions", 0,9999999, 1.5));
         }

--- a/src/modules/featuredetection/featuredetectionmodule.cxx
+++ b/src/modules/featuredetection/featuredetectionmodule.cxx
@@ -106,7 +106,7 @@ class MonotonyFeatureDetector
                         new_feature_list = detectFeaturesUsingMonotonyOperator(imageband,
                                                                                param_lowestMonotonyClass->value(), param_highestMonotonyClass->value());
                     }
-                    new_feature_list->setName(QString("Monotony Features of ") + param_imageBand->valueText());
+                    new_feature_list->setName(QString("Monotony Features of ") + param_imageBand->toString());
                     QString descr("The following parameters were used to determine the Monotony Features:\n");
                     descr += m_parameters->valueText("ModelParameter");
                     
@@ -213,7 +213,7 @@ class HarrisCornerDetector
                                                                      param_gradientSigma->value(), param_responseThreshold->value());
                     }
                         
-                    new_feature_list->setName(QString("Harris Features of ") + param_imageBand->valueText());
+                    new_feature_list->setName(QString("Harris Features of ") + param_imageBand->toString());
                     QString descr("The following parameters were used to determine the Harris Features:\n");
                     descr += m_parameters->valueText("ModelParameter");
                     new_feature_list->setDescription(descr);
@@ -317,7 +317,7 @@ class CannyFeatureDetector
                                                                           param_cannyScale->value(), param_cannyThreshold->value());
                     }
                     
-                    new_edgel_feature_list->setName(QString("Canny-Edgel Features of ") + param_imageBand->valueText());
+                    new_edgel_feature_list->setName(QString("Canny-Edgel Features of ") + param_imageBand->toString());
                     QString descr("The following parameters were used to determine the Canny-Edgel Features:\n");
                     descr += m_parameters->valueText("ModelParameter");
                     
@@ -574,7 +574,7 @@ class SIFTFeatureDetector
                                                                                    param_sigma->value(), param_octaves->value(), param_levels->value(),
                                                                                    param_contrast_threshold->value(), param_curvature_threshold->value(), param_double_size->value(), param_normalize->value());
                     
-                    new_feature_list->setName(QString("SIFT Features of ") + param_imageBand->valueText());
+                    new_feature_list->setName(QString("SIFT Features of ") + param_imageBand->toString());
                     QString descr("The following parameters were used to determine the SIFT Features:\n");
                     descr += m_parameters->valueText("ModelParameter");
                     

--- a/src/modules/featurematching/featurematchingmodule.cxx
+++ b/src/modules/featurematching/featurematchingmodule.cxx
@@ -142,7 +142,7 @@ class BlockWiseImageMatcher
                     
                     qint64 processing_time = timer.elapsed();
                     
-                    new_block_matching_vectorfield->setName(QString("I->I block matching with ") + param_imageBand1->valueText() + QString(" and ") + param_imageBand2->valueText());
+                    new_block_matching_vectorfield->setName(QString("I->I block matching with ") + param_imageBand1->toString() + QString(" and ") + param_imageBand2->toString());
                     
                     QString descr("The following parameters were used to calculate the Block Matching (Image->Image):\n");
                     descr += m_parameters->valueText("ModelParameter");
@@ -151,7 +151,7 @@ class BlockWiseImageMatcher
                                          mat(0,1), mat(1,1), mat(2,1),
                                          mat(0,2), mat(1,2), mat(2,2));
                     
-                    QString mat_str = TransformParameter::valueText(transform);
+                    QString mat_str = "";//TODO:TransformParameter::valueText(transform);
                     
                     descr += QString(   "Computed global motion matrix (I1 -> I2): %1\n"
                                         "rotation accuracy: %2\n"
@@ -306,7 +306,7 @@ class FeatureToFeatureMatcher
                     
                     qint64 processing_time = timer.elapsed();
                     
-                    new_vectorfield->setName(QString("F->F matching with ") + param_imageBand1->valueText() + QString(" and ") + param_imageBand2->valueText());
+                    new_vectorfield->setName(QString("F->F matching with ") + param_imageBand1->toString() + QString(" and ") + param_imageBand2->toString());
                     
                     QString descr("The following parameters were used to calculate the NCC (Features->Features):\n");
                     descr += m_parameters->valueText("ModelParameter");
@@ -315,7 +315,7 @@ class FeatureToFeatureMatcher
                                          mat(0,1), mat(1,1), mat(2,1),
                                          mat(0,2), mat(1,2), mat(2,2));
 
-                    QString mat_str = TransformParameter::valueText(transform);
+                    QString mat_str = "";//TODO:TransformParameter::valueText(transform);
                     
                     descr += QString(   "Computed global motion matrix (I1 -> I2): %1\n"
                                         "rotation accuracy: %2\n"
@@ -468,7 +468,7 @@ class FeatureToImageMatcher
                     
                     qint64 processing_time = timer.elapsed();
                     
-                    new_vectorfield->setName(QString("F->I Matching with ") + param_imageBand1->valueText() + QString(" and ") + param_imageBand2->valueText());
+                    new_vectorfield->setName(QString("F->I Matching with ") + param_imageBand1->toString() + QString(" and ") + param_imageBand2->toString());
                     
                     QString descr("The following parameters were used to calculate the matching (Features->Image):\n");
                     descr += m_parameters->valueText("ModelParameter");
@@ -477,7 +477,7 @@ class FeatureToImageMatcher
                                          mat(0,1), mat(1,1), mat(2,1),
                                          mat(0,2), mat(1,2), mat(2,2));
 
-                    QString mat_str = TransformParameter::valueText(transform);
+                    QString mat_str = "";//TODO:TransformParameter::valueText(transform);
                     
                     descr += QString(   "Computed global motion matrix (I1 -> I2): %1\n"
                                         "rotation accuracy: %2\n"
@@ -635,7 +635,7 @@ class ShapeContextMatcher
                                          mat(0,1), mat(1,1), mat(2,1),
                                          mat(0,2), mat(1,2), mat(2,2));
 
-                    QString mat_str = TransformParameter::valueText(transform);
+                    QString mat_str = "";//TODO:TransformParameter::valueText(transform);
                     
                     descr += QString(   "Computed global motion matrix (I1 -> I2): %1\n"
                                         "rotation accuracy: %2\n"
@@ -789,7 +789,7 @@ class SIFTMatcher
                                          mat(0,1), mat(1,1), mat(2,1),
                                          mat(0,2), mat(1,2), mat(2,2));
 
-                    QString mat_str = TransformParameter::valueText(transform);
+                    QString mat_str = "";//TODO:TransformParameter::valueText(transform);
                     
                     descr += QString(   "Computed global motion matrix (I1 -> I2): %1\n"
                                         "rotation accuracy: %2\n"

--- a/src/modules/featurematching/featurematchingmodule.cxx
+++ b/src/modules/featurematching/featurematchingmodule.cxx
@@ -229,10 +229,10 @@ class FeatureToFeatureMatcher
          */
         FeatureToFeatureMatcher()
         {
-            m_parameters->addParameter("image1",    new ImageBandParameter<float>("Reference image",	NULL));
-            m_parameters->addParameter("features1", new ModelParameter("Features (of reference image)",	NULL,  "PointFeatureList2D | WeightedPointFeatureList2D | EdgelFeatureList2D"));
-            m_parameters->addParameter("image2",    new ImageBandParameter<float>("Second Image",	NULL));
-            m_parameters->addParameter("features2", new ModelParameter("Features (of second image)",		NULL,  "PointFeatureList2D | WeightedPointFeatureList2D | EdgelFeatureList2D"));
+            m_parameters->addParameter("image1",    new ImageBandParameter<float>("Reference image"));
+            m_parameters->addParameter("features1", new ModelParameter("Features (of reference image)",  "PointFeatureList2D | WeightedPointFeatureList2D | EdgelFeatureList2D"));
+            m_parameters->addParameter("image2",    new ImageBandParameter<float>("Second Image"));
+            m_parameters->addParameter("features2", new ModelParameter("Features (of second image)",  "PointFeatureList2D | WeightedPointFeatureList2D | EdgelFeatureList2D"));
             m_parameters->addParameter("mask_w",    new IntParameter("Mask width", 3, 999));
             m_parameters->addParameter("mask_h",    new IntParameter("Mask height", 3, 999));
             m_parameters->addParameter("max_d",     new IntParameter("Max Distance", 1, 999));
@@ -395,9 +395,9 @@ class FeatureToImageMatcher
          */
         FeatureToImageMatcher()
         {
-            m_parameters->addParameter("image1",    new ImageBandParameter<float>("Reference image",	NULL));
-            m_parameters->addParameter("features1", new ModelParameter("Features (of reference image)",	NULL,  "PointFeatureList2D | WeightedPointFeatureList2D | EdgelFeatureList2D"));
-            m_parameters->addParameter("image2",    new ImageBandParameter<float>("Second Image",	NULL));
+            m_parameters->addParameter("image1",    new ImageBandParameter<float>("Reference image"));
+            m_parameters->addParameter("features1", new ModelParameter("Features (of reference image)", "PointFeatureList2D | WeightedPointFeatureList2D | EdgelFeatureList2D"));
+            m_parameters->addParameter("image2",    new ImageBandParameter<float>("Second Image"));
             m_parameters->addParameter("mask_w",    new IntParameter("Mask width", 3, 999));
             m_parameters->addParameter("mask_h",    new IntParameter("Mask height", 3, 999));
             m_parameters->addParameter("max_d",     new IntParameter("Max Distance", 1, 999));
@@ -556,10 +556,10 @@ class ShapeContextMatcher
          */
         ShapeContextMatcher()
         {
-            m_parameters->addParameter("image1",    new ImageBandParameter<float>("Reference image",	NULL));
-            m_parameters->addParameter("features1", new ModelParameter("Features (of reference image)",	NULL,  "PointFeatureList2D | WeightedPointFeatureList2D | EdgelFeatureList2D"));
-            m_parameters->addParameter("image2",    new ImageBandParameter<float>("Second Image",	NULL));
-            m_parameters->addParameter("features2", new ModelParameter("Features (of second image)",		NULL,  "PointFeatureList2D | WeightedPointFeatureList2D | EdgelFeatureList2D"));
+            m_parameters->addParameter("image1",    new ImageBandParameter<float>("Reference image"));
+            m_parameters->addParameter("features1", new ModelParameter("Features (of reference image)", "PointFeatureList2D | WeightedPointFeatureList2D | EdgelFeatureList2D"));
+            m_parameters->addParameter("image2",    new ImageBandParameter<float>("Second Image"));
+            m_parameters->addParameter("features2", new ModelParameter("Features (of second image)", "PointFeatureList2D | WeightedPointFeatureList2D | EdgelFeatureList2D"));
             m_parameters->addParameter("mask_w",    new IntParameter("Mask width", 3, 999));
             m_parameters->addParameter("mask_h",    new IntParameter("Mask height", 3, 999));
             m_parameters->addParameter("max_d",     new IntParameter("Max Distance", 1, 999));
@@ -703,10 +703,10 @@ class SIFTMatcher
          */
         SIFTMatcher()
         {
-            m_parameters->addParameter("image1", new ImageBandParameter<float>("Reference image",	NULL));
-            m_parameters->addParameter("sift1", new ModelParameter("SIFT Features (of reference image)",	NULL,  "SIFTFeatureList2D"));
-            m_parameters->addParameter("image2", new ImageBandParameter<float>("Second Image",	NULL));
-            m_parameters->addParameter("sift2", new ModelParameter("SIFT Features (of second image)",		NULL,  "SIFTFeatureList2D"));
+            m_parameters->addParameter("image1", new ImageBandParameter<float>("Reference image"));
+            m_parameters->addParameter("sift1", new ModelParameter("SIFT Features (of reference image)", "SIFTFeatureList2D"));
+            m_parameters->addParameter("image2", new ImageBandParameter<float>("Second Image"));
+            m_parameters->addParameter("sift2", new ModelParameter("SIFT Features (of second image)", "SIFTFeatureList2D"));
             m_parameters->addParameter("max_sift_d", new FloatParameter("Max. distance of point descriptors", 1, 1000000,1000));
             m_parameters->addParameter("max_d", new FloatParameter("Max. geometrical distance of points", 1, 100000,100));
             m_parameters->addParameter("best_n", new IntParameter("Find N best candidates", 1, 50,10));

--- a/src/modules/features2d/cubicsplinelist.cxx
+++ b/src/modules/features2d/cubicsplinelist.cxx
@@ -248,9 +248,10 @@ void CubicSplineList2D::serialize_content(QXmlStreamWriter& xmlWriter) const
  *
  * \param in The QIODevice, where we will read from.
  */
-bool CubicSplineList2D::deserialize_content(QIODevice& in)
+bool CubicSplineList2D::deserialize_content(QXmlStreamReader& xmlReader)
 {
-    if(locked())
+//TODO!!!
+/**    if(locked())
         return false;
         
     //Read in header line and then throw it away immideately
@@ -277,6 +278,8 @@ bool CubicSplineList2D::deserialize_content(QIODevice& in)
         }
     }
     return true;
+    */
+    return false;
 }
 
 

--- a/src/modules/features2d/cubicsplinelist.cxx
+++ b/src/modules/features2d/cubicsplinelist.cxx
@@ -64,7 +64,7 @@ CubicSplineList2D::CubicSplineList2D(const CubicSplineList2D& spline_list)
  *
  * \return Always "CubicSplineList2D".
  */
-QString CubicSplineList2D::typeName()
+QString CubicSplineList2D::typeName() const
 {
 	return "CubicSplineList2D";
 }
@@ -304,7 +304,7 @@ WeightedCubicSplineList2D::WeightedCubicSplineList2D(const WeightedCubicSplineLi
  *
  * \return Always "WeightedCubicSplineList2D".
  */
-QString WeightedCubicSplineList2D::typeName()
+QString WeightedCubicSplineList2D::typeName() const
 {
 	return "WeightedCubicSplineList2D";
 }

--- a/src/modules/features2d/cubicsplinelist.cxx
+++ b/src/modules/features2d/cubicsplinelist.cxx
@@ -222,11 +222,11 @@ bool CubicSplineList2D::deserialize_item(const QString & serial)
 }
 
 /**
- * Serialization the list of 2D cubic splines to a QIODevice.
+ * Serialization the list of 2D cubic splines to an xml file.
  * The first line is the header as given in item_header(). Each following
  * line represents one 2D cubic spline serialization.
  *
- * \param out The QIODevice, where we will put our output on.
+ * \param xmlWriter The QXmlStreamWriter where we will put our output on.
  */
 void CubicSplineList2D::serialize_content(QXmlStreamWriter& xmlWriter) const
 {
@@ -242,11 +242,11 @@ void CubicSplineList2D::serialize_content(QXmlStreamWriter& xmlWriter) const
 }
 
 /**
- * Deserializion of a list of 2D cubic splines from a QIODevice.
+ * Deserialization of a list of 2D cubic splines from an xml file.
  * The first line is the header as given in item_header(), which is ignored however.
- * Each following line has to be one valide 2D cubic spline serialization.
+ * Each following line has to be one valid 2D cubic spline serialization.
  *
- * \param in The QIODevice, where we will read from.
+ * \param xmlReader The QXmlStreamReader, where we will read from.
  */
 bool CubicSplineList2D::deserialize_content(QXmlStreamReader& xmlReader)
 {

--- a/src/modules/features2d/cubicsplinelist.cxx
+++ b/src/modules/features2d/cubicsplinelist.cxx
@@ -228,14 +228,17 @@ bool CubicSplineList2D::deserialize_item(const QString & serial)
  *
  * \param out The QIODevice, where we will put our output on.
  */
-void CubicSplineList2D::serialize_content(QIODevice& out) const
+void CubicSplineList2D::serialize_content(QXmlStreamWriter& xmlWriter) const
 {
+//TODO!!!
+/**
 	write_on_device(item_header(), out);
     
 	for(unsigned int i=0; i < size(); ++i)
     {
 		write_on_device("\n" + serialize_item(i), out);
 	}
+    */
 }
 
 /**

--- a/src/modules/features2d/cubicsplinelist.cxx
+++ b/src/modules/features2d/cubicsplinelist.cxx
@@ -230,15 +230,15 @@ bool CubicSplineList2D::deserialize_item(const QString & serial)
  */
 void CubicSplineList2D::serialize_content(QXmlStreamWriter& xmlWriter) const
 {
-//TODO!!!
-/**
-	write_on_device(item_header(), out);
+    xmlWriter.writeTextElement("Legend", item_header());
     
 	for(unsigned int i=0; i < size(); ++i)
     {
-		write_on_device("\n" + serialize_item(i), out);
-	}
-    */
+        xmlWriter.writeStartElement("CubicSpline");
+        xmlWriter.writeAttribute("ID", QString::number(i));
+            xmlWriter.writeCharacters(serialize_item(i));
+        xmlWriter.writeEndElement();
+    }
 }
 
 /**
@@ -250,35 +250,27 @@ void CubicSplineList2D::serialize_content(QXmlStreamWriter& xmlWriter) const
  */
 bool CubicSplineList2D::deserialize_content(QXmlStreamReader& xmlReader)
 {
-//TODO!!!
-/**    if(locked())
+    if (locked())
         return false;
-        
-    //Read in header line and then throw it away immideately
-    if(!in.atEnd())
-        in.readLine();
-    
+
     //Clean up
 	clear();
     updateModel();
     
     //Read the entries
-    while(!in.atEnd())
+    while(xmlReader.readNextStartElement())
     {
-        QString line = QString(in.readLine());
-        
-        //ignore comments and empty lines
-        if(!line.isEmpty() && !line.startsWith(";"))
+        if(xmlReader.name() == "CubicSpline")
         {
-            if (!deserialize_item(line))
-            {
-                qCritical() << "CubicSplineList2D::deserialize_content: Spline could not be deserialized from: '" << line << "'";
+            if(!deserialize_item(xmlReader.readElementText()))
                 return false;
-            }
+        }
+        else
+        {
+            xmlReader.skipCurrentElement();
         }
     }
     return true;
-    */
     return false;
 }
 

--- a/src/modules/features2d/cubicsplinelist.cxx
+++ b/src/modules/features2d/cubicsplinelist.cxx
@@ -152,7 +152,7 @@ QString CubicSplineList2D::csvHeader() const
  * \return A QString containing the searialization of the 2D cubic spline.
  *         The serialization should be given as: dp0/dx, dp0/dy, p0_x, p0_y, ... , pN_x, pN_y, dpN/dx, dpN/dy
  */
-QString CubicSplineList2D::serialize_item(unsigned int index) const
+QString CubicSplineList2D::itemToCSV(unsigned int index) const
 {
 
     CubicSplineType::PointType first_derivative = m_splines[index].derive(0),
@@ -161,7 +161,7 @@ QString CubicSplineList2D::serialize_item(unsigned int index) const
     
     QString result = QString::number(first_derivative.x(), 'g', 10) + ", " + QString::number(first_derivative.y(), 'g', 10);
 	
-	for(unsigned int i=0; i < size(); ++i)
+	for(unsigned int i=0; i < points.size(); ++i)
     {
 		result +=    ", " + QString::number(points[i].x(), 'g', 10)
                    + ", " + QString::number(points[i].y(), 'g', 10);
@@ -178,7 +178,7 @@ QString CubicSplineList2D::serialize_item(unsigned int index) const
  * \param serial A QString containing the searialization of the 2D cubic spline.
  * \return True, if the item could be deserialized and the model is not locked.
  */
-bool CubicSplineList2D::deserialize_item(const QString & serial)
+bool CubicSplineList2D::itemFromCSV(const QString & serial)
 {
     if(locked())
         return false;
@@ -220,6 +220,128 @@ bool CubicSplineList2D::deserialize_item(const QString & serial)
     m_splines.push_back(CubicSplineType(points, first_derivative, last_derivative));
     return true;
 }
+/**
+ * Serialization of one 2D cubic spline at a given list index to a string. This function will
+         * throw an error if the index is out of range.
+ *
+ * \param index The index of the 2D cubic spline to be serialized.
+ * \return A QString containing the searialization of the 2D cubic spline.
+ *         The serialization should be given as: dp0/dx, dp0/dy, p0_x, p0_y, ... , pN_x, pN_y, dpN/dx, dpN/dy
+ */
+void CubicSplineList2D::serialize_item(unsigned int index, QXmlStreamWriter& xmlWriter) const
+{
+    CubicSplineType::PointType first_derivative = m_splines[index].derive(0),
+                               last_derivative = m_splines[index].derive(1);
+    CubicSplineType::PointListType points = m_splines[index].points() ;
+    
+        xmlWriter.writeStartElement("Derivative");
+            xmlWriter.writeAttribute("ID", "0");
+            xmlWriter.writeTextElement("x", QString::number(first_derivative.x(), 'g', 10));
+            xmlWriter.writeTextElement("y", QString::number(first_derivative.y(), 'g', 10));
+        xmlWriter.writeEndElement();
+    
+	for(unsigned int i=0; i < points.size(); ++i)
+    {
+        xmlWriter.writeStartElement("Point");
+            xmlWriter.writeAttribute("ID", QString::number(i));
+            xmlWriter.writeTextElement("x", QString::number(points[i].x(), 'g', 10));
+            xmlWriter.writeTextElement("y", QString::number(points[i].y(), 'g', 10));
+        xmlWriter.writeEndElement();
+    }
+    
+        xmlWriter.writeStartElement("Derivative");
+            xmlWriter.writeAttribute("ID", QString::number(points.size()-1));
+            xmlWriter.writeTextElement("x", QString::number(last_derivative.x(), 'g', 10));
+            xmlWriter.writeTextElement("y", QString::number(last_derivative.y(), 'g', 10));
+        xmlWriter.writeEndElement();
+}
+
+/**
+ * Deserialization/addition of a 2D cubic spline from a string to this list.
+ *
+ * \param serial A QString containing the searialization of the 2D cubic spline.
+ * \return True, if the item could be deserialized and the model is not locked.
+ */
+bool CubicSplineList2D::deserialize_item(QXmlStreamReader& xmlReader)
+{
+    if(locked())
+        return false;
+    
+    CubicSplineType::PointType first_derivative, last_derivative;
+    CubicSplineType::PointListType points;
+	
+    if(/*     xmlReader.readNextStartElement()
+        &&*/  xmlReader.name() == "CubicSpline2D"
+        &&  xmlReader.attributes().hasAttribute("Points"))
+    {
+        int size = xmlReader.attributes().value("Points").toInt();
+        points.resize(size);
+        
+        if(     xmlReader.readNextStartElement()
+            && xmlReader.name() == "Derivative"
+            && xmlReader.attributes().hasAttribute("ID")
+            && xmlReader.attributes().value("ID").toInt() == 0)
+        {
+            if(     xmlReader.readNextStartElement()
+                &&  xmlReader.name() == "x")
+            {
+                first_derivative.setX(xmlReader.readElementText().toFloat());
+            }
+            if(     xmlReader.readNextStartElement()
+                &&  xmlReader.name() == "y")
+            {
+                first_derivative.setY(xmlReader.readElementText().toFloat());
+            }
+        }
+        
+        for(int i=0; i!=size; ++i)
+        {
+            if(     xmlReader.readNextStartElement()
+                &&  xmlReader.name() == "Point"
+                &&  xmlReader.attributes().hasAttribute("ID")
+                &&  xmlReader.attributes().value("ID").toInt() == i)
+            {
+                
+                if(     xmlReader.readNextStartElement()
+                    &&  xmlReader.name() == "x")
+                {
+                    points[i].setX(xmlReader.readElementText().toFloat());
+                }
+                if(     xmlReader.readNextStartElement()
+                    &&  xmlReader.name() == "y")
+                {
+                    points[i].setY(xmlReader.readElementText().toFloat());
+                }
+            }
+        }
+        
+        if(    xmlReader.readNextStartElement()
+            && xmlReader.name() == "Derivative"
+            && xmlReader.attributes().hasAttribute("ID")
+            && xmlReader.attributes().value("ID").toInt() == size-1)
+        {
+            if(     xmlReader.readNextStartElement()
+               &&   xmlReader.name() == "x")
+            {
+                last_derivative.setX(xmlReader.readElementText().toFloat());
+            }
+            if(     xmlReader.readNextStartElement()
+               &&   xmlReader.name() == "y")
+            {
+                last_derivative.setY(xmlReader.readElementText().toFloat());
+            }
+        }
+        
+    }
+    else
+    {
+        qWarning() << "Did not find matching start attribute";
+        return false;
+    }
+    
+    m_splines.push_back(CubicSplineType(points, first_derivative, last_derivative));
+    return true;
+}
 
 /**
  * Serialization the list of 2D cubic splines to an xml file.
@@ -230,13 +352,13 @@ bool CubicSplineList2D::deserialize_item(const QString & serial)
  */
 void CubicSplineList2D::serialize_content(QXmlStreamWriter& xmlWriter) const
 {
-    xmlWriter.writeTextElement("Legend", csvHeader());
-    
 	for(unsigned int i=0; i < size(); ++i)
     {
-        xmlWriter.writeStartElement("CubicSpline");
-        xmlWriter.writeAttribute("ID", QString::number(i));
-            xmlWriter.writeCharacters(serialize_item(i));
+        xmlWriter.writeStartElement("CubicSpline2D");
+            xmlWriter.writeAttribute("ID", QString::number(i));
+            xmlWriter.writeAttribute("Points", QString::number(m_splines[i].points().size()));
+        
+            serialize_item(i, xmlWriter);
         xmlWriter.writeEndElement();
     }
 }
@@ -260,9 +382,9 @@ bool CubicSplineList2D::deserialize_content(QXmlStreamReader& xmlReader)
     //Read the entries
     while(xmlReader.readNextStartElement())
     {
-        if(xmlReader.name() == "CubicSpline")
+        if(xmlReader.name() == "CubicSpline2D")
         {
-            if(!deserialize_item(xmlReader.readElementText()))
+            if(!deserialize_item(xmlReader))
                 return false;
         }
         else
@@ -271,7 +393,6 @@ bool CubicSplineList2D::deserialize_content(QXmlStreamReader& xmlReader)
         }
     }
     return true;
-    return false;
 }
 
 
@@ -411,9 +532,9 @@ QString WeightedCubicSplineList2D::csvHeader() const
  * \return A QString containing the searialization of the 2D cubic spline.
  *         The serialization should be given as: weight, dp0/dx, dp0/dy, p0_x, p0_y, ... , pN_x, pN_y, dpN/dx, dpN/dy
  */
-QString WeightedCubicSplineList2D::serialize_item(unsigned int index) const
+QString WeightedCubicSplineList2D::itemToCSV(unsigned int index) const
 {
-    return QString("%1, %2").arg(m_weights[index]).arg(CubicSplineList2D::serialize_item(index));
+    return QString("%1, %2").arg(m_weights[index]).arg(CubicSplineList2D::itemToCSV(index));
 }
 
 /**
@@ -422,7 +543,7 @@ QString WeightedCubicSplineList2D::serialize_item(unsigned int index) const
  * \param serial A QString containing the searialization of the 2D cubic spline.
  * \return True, if the item could be deserialized and the model is not locked.
  */
-bool WeightedCubicSplineList2D::deserialize_item(const QString & serial)
+bool WeightedCubicSplineList2D::itemFromCSV(const QString & serial)
 {
     if(locked())
         return false;    
@@ -434,7 +555,7 @@ bool WeightedCubicSplineList2D::deserialize_item(const QString & serial)
     {
 		try
         {
-			bool res = CubicSplineList2D::deserialize_item(weight_content[1]);
+			bool res = CubicSplineList2D::itemFromCSV(weight_content[1]);
 			if (res)
             {
                 m_weights.push_back(weight_content[0].toFloat());
@@ -449,6 +570,45 @@ bool WeightedCubicSplineList2D::deserialize_item(const QString & serial)
 		}
 	}
 	return false;
+}
+/**
+ * Serialization of one 2D cubic spline at a given list index to a string. This function will
+ * throw an error if the index is out of range.
+ *
+ * \param index The index of the 2D cubic spline to be serialized.
+ * \return A QString containing the searialization of the 2D cubic spline.
+ *         The serialization should be given as: weight, dp0/dx, dp0/dy, p0_x, p0_y, ... , pN_x, pN_y, dpN/dx, dpN/dy
+ */
+void WeightedCubicSplineList2D::serialize_item(unsigned int index, QXmlStreamWriter& xmlWriter) const
+{
+    CubicSplineList2D::serialize_item(index, xmlWriter);
+    
+    xmlWriter.writeTextElement("weight",  QString::number(m_weights[index], 'g', 10));
+}
+
+/**
+ * Deserialization/addition of a 2D cubic spline from a string to this list.
+ *
+ * \param serial A QString containing the searialization of the 2D cubic spline.
+ * \return True, if the item could be deserialized and the model is not locked.
+ */
+bool WeightedCubicSplineList2D::deserialize_item(QXmlStreamReader& xmlReader)
+{
+    if(locked())
+        return false;    
+    
+	if (!CubicSplineList2D::deserialize_item(xmlReader))
+    {
+        return false;
+    }
+    
+    if(     xmlReader.readNextStartElement()
+        &&  xmlReader.name() == "weight")
+    {
+        m_weights.push_back(xmlReader.readElementText().toFloat());
+        return true;
+    }
+    return false;
 }
     
 } //End of namespace graipe

--- a/src/modules/features2d/cubicsplinelist.cxx
+++ b/src/modules/features2d/cubicsplinelist.cxx
@@ -64,7 +64,7 @@ CubicSplineList2D::CubicSplineList2D(const CubicSplineList2D& spline_list)
  *
  * \return Always "CubicSplineList2D".
  */
-QString CubicSplineList2D::typeName() const
+QString CubicSplineList2D::typeName()
 {
 	return "CubicSplineList2D";
 }
@@ -138,7 +138,7 @@ void CubicSplineList2D::addSpline(const CubicSplineType& spl)
  *
  * \return Always "dp0/dx, dp0/dy, p0_x, p0_y, p1_x, p1_y, ... , pN_x, pN_y, dpN/dx, dpN/dy".
  */
-QString CubicSplineList2D::item_header() const
+QString CubicSplineList2D::csvHeader() const
 {
 	return "dp0/dx, dp0/dy, p0_x, p0_y, p1_x, p1_y, ... , pN_x, pN_y, dpN/dx, dpN/dy";
 }
@@ -223,14 +223,14 @@ bool CubicSplineList2D::deserialize_item(const QString & serial)
 
 /**
  * Serialization the list of 2D cubic splines to an xml file.
- * The first line is the header as given in item_header(). Each following
+ * The first line is the header as given in csvHeader. Each following
  * line represents one 2D cubic spline serialization.
  *
  * \param xmlWriter The QXmlStreamWriter where we will put our output on.
  */
 void CubicSplineList2D::serialize_content(QXmlStreamWriter& xmlWriter) const
 {
-    xmlWriter.writeTextElement("Legend", item_header());
+    xmlWriter.writeTextElement("Legend", csvHeader());
     
 	for(unsigned int i=0; i < size(); ++i)
     {
@@ -243,7 +243,7 @@ void CubicSplineList2D::serialize_content(QXmlStreamWriter& xmlWriter) const
 
 /**
  * Deserialization of a list of 2D cubic splines from an xml file.
- * The first line is the header as given in item_header(), which is ignored however.
+ * The first line is the header as given in csvHeader, which is ignored however.
  * Each following line has to be one valid 2D cubic spline serialization.
  *
  * \param xmlReader The QXmlStreamReader, where we will read from.
@@ -304,7 +304,7 @@ WeightedCubicSplineList2D::WeightedCubicSplineList2D(const WeightedCubicSplineLi
  *
  * \return Always "WeightedCubicSplineList2D".
  */
-QString WeightedCubicSplineList2D::typeName() const
+QString WeightedCubicSplineList2D::typeName()
 {
 	return "WeightedCubicSplineList2D";
 }
@@ -398,9 +398,9 @@ void WeightedCubicSplineList2D::addSpline(const CubicSplineType& spl, float w)
  *
  * \return Always "weight, dp0/dx, dp0/dy, p0_x, p0_y, p1_x, p1_y, ... , pN_x, pN_y, dpN/dx, dpN/dy".
  */
-QString WeightedCubicSplineList2D::item_header() const
+QString WeightedCubicSplineList2D::csvHeader() const
 {
-    return "weight, " + CubicSplineList2D::item_header();
+    return "weight, " + CubicSplineList2D::csvHeader();
 }
     
 /**

--- a/src/modules/features2d/cubicsplinelist.cxx
+++ b/src/modules/features2d/cubicsplinelist.cxx
@@ -571,6 +571,7 @@ bool WeightedCubicSplineList2D::itemFromCSV(const QString & serial)
 	}
 	return false;
 }
+
 /**
  * Serialization of one 2D cubic spline at a given list index to a string. This function will
  * throw an error if the index is out of range.

--- a/src/modules/features2d/cubicsplinelist.hxx
+++ b/src/modules/features2d/cubicsplinelist.hxx
@@ -153,7 +153,7 @@ class GRAIPE_FEATURES2D_EXPORT CubicSplineList2D
          *
          * \param in The QIODevice, where we will read from.
          */
-		bool deserialize_content(QIODevice& in);
+		bool deserialize_content(QXmlStreamReader& xmlReader);
 	
     protected:
         //The list of 2D cubic splines

--- a/src/modules/features2d/cubicsplinelist.hxx
+++ b/src/modules/features2d/cubicsplinelist.hxx
@@ -138,20 +138,20 @@ class GRAIPE_FEATURES2D_EXPORT CubicSplineList2D
         virtual bool deserialize_item(const QString & serial);
     
         /**
-         * Serialization the list of 2D cubic splines to a QIODevice.
+         * Serialization the list of 2D cubic splines to an xml file.
          * The first line is the header as given in item_header(). Each following
          * line represents one 2D cubic spline serialization.
          *
-         * \param out The QIODevice, where we will put our output on.
+         * \param xmlWriter The QXmlStreamWriter where we will put our output on.
          */
 		void serialize_content(QXmlStreamWriter& xmlWriter) const;
     
         /**
-         * Deserializion of a list of 2D cubic splines from a QIODevice.
+         * Deserialization of a list of 2D cubic splines from an xml file.
          * The first line is the header as given in item_header(), which is ignored however.
-         * Each following line has to be one valide 2D cubic spline serialization.
+         * Each following line has to be one valid 2D cubic spline serialization.
          *
-         * \param in The QIODevice, where we will read from.
+         * \param xmlReader The QXmlStreamReader, where we will read from.
          */
 		bool deserialize_content(QXmlStreamReader& xmlReader);
 	

--- a/src/modules/features2d/cubicsplinelist.hxx
+++ b/src/modules/features2d/cubicsplinelist.hxx
@@ -73,7 +73,7 @@ class GRAIPE_FEATURES2D_EXPORT CubicSplineList2D
          *
          * \return Always "CubicSplineList2D".
          */
-		static QString typeName();
+		virtual QString typeName() const;
 		
         /**
          * Returns the number of 2D cubic splines in this list.
@@ -190,7 +190,7 @@ class GRAIPE_FEATURES2D_EXPORT WeightedCubicSplineList2D
          *
          * \return Always "WeightedCubicSplineList2D".
          */
-        static QString typeName();
+        virtual QString typeName() const;
     
         /**
          * Getter of the weight of a 2D cubic spline at a given index. May throw an error,

--- a/src/modules/features2d/cubicsplinelist.hxx
+++ b/src/modules/features2d/cubicsplinelist.hxx
@@ -73,7 +73,7 @@ class GRAIPE_FEATURES2D_EXPORT CubicSplineList2D
          *
          * \return Always "CubicSplineList2D".
          */
-		QString typeName() const;
+		static QString typeName();
 		
         /**
          * Returns the number of 2D cubic splines in this list.
@@ -117,7 +117,7 @@ class GRAIPE_FEATURES2D_EXPORT CubicSplineList2D
          *
          * \return Always "dp0/dx, dp0/dy, p0_x, p0_y, p1_x, p1_y, ... , pN_x, pN_y, dpN/dx, dpN/dy".
          */
-		virtual QString item_header() const;
+		virtual QString csvHeader() const;
     
         /**
          * Serialization of one 2D cubic spline at a given list index to a string. This function will
@@ -139,7 +139,7 @@ class GRAIPE_FEATURES2D_EXPORT CubicSplineList2D
     
         /**
          * Serialization the list of 2D cubic splines to an xml file.
-         * The first line is the header as given in item_header(). Each following
+         * The first line is the header as given in csvHeader. Each following
          * line represents one 2D cubic spline serialization.
          *
          * \param xmlWriter The QXmlStreamWriter where we will put our output on.
@@ -148,7 +148,7 @@ class GRAIPE_FEATURES2D_EXPORT CubicSplineList2D
     
         /**
          * Deserialization of a list of 2D cubic splines from an xml file.
-         * The first line is the header as given in item_header(), which is ignored however.
+         * The first line is the header as given in csvHeader, which is ignored however.
          * Each following line has to be one valid 2D cubic spline serialization.
          *
          * \param xmlReader The QXmlStreamReader, where we will read from.
@@ -190,7 +190,7 @@ class GRAIPE_FEATURES2D_EXPORT WeightedCubicSplineList2D
          *
          * \return Always "WeightedCubicSplineList2D".
          */
-        QString typeName() const;
+        static QString typeName();
     
         /**
          * Getter of the weight of a 2D cubic spline at a given index. May throw an error,
@@ -254,7 +254,7 @@ class GRAIPE_FEATURES2D_EXPORT WeightedCubicSplineList2D
          *
          * \return Always "weight, dp0/dx, dp0/dy, p0_x, p0_y, p1_x, p1_y, ... , pN_x, pN_y, dpN/dx, dpN/dy".
          */
-		virtual QString item_header() const;
+		virtual QString csvHeader() const;
     
         /**
          * Serialization of one 2D cubic spline at a given list index to a string. This function will

--- a/src/modules/features2d/cubicsplinelist.hxx
+++ b/src/modules/features2d/cubicsplinelist.hxx
@@ -144,7 +144,7 @@ class GRAIPE_FEATURES2D_EXPORT CubicSplineList2D
          *
          * \param out The QIODevice, where we will put our output on.
          */
-		void serialize_content(QIODevice& out) const;
+		void serialize_content(QXmlStreamWriter& xmlWriter) const;
     
         /**
          * Deserializion of a list of 2D cubic splines from a QIODevice.

--- a/src/modules/features2d/cubicsplinelist.hxx
+++ b/src/modules/features2d/cubicsplinelist.hxx
@@ -126,7 +126,7 @@ class GRAIPE_FEATURES2D_EXPORT CubicSplineList2D
          * \param index The index of the 2D cubic spline to be serialized.
          * \return A QString containing the searialization of the 2D cubic spline.
          */
-        virtual QString serialize_item(unsigned int index) const;
+        virtual QString itemToCSV(unsigned int index) const;
     
         /**
          * Deserialization/addition of a 2D cubic spline from a string to this list.
@@ -135,7 +135,25 @@ class GRAIPE_FEATURES2D_EXPORT CubicSplineList2D
          * \return True, if the item could be deserialized and the model is not locked.
          *         The serialization should be given as: dp0/dx, dp0/dy, p0_x, p0_y, ... , pN_x, pN_y, dpN/dx, dpN/dy
          */
-        virtual bool deserialize_item(const QString & serial);
+        virtual bool itemFromCSV(const QString & serial);
+    
+        /**
+         * Serialization of one 2D cubic spline at a given list index to a string. This function will
+         * throw an error if the index is out of range.
+         *
+         * \param index The index of the 2D cubic spline to be serialized.
+         * \return A QString containing the searialization of the 2D cubic spline.
+         */
+        virtual void serialize_item(unsigned int index, QXmlStreamWriter& xmlWriter) const;
+    
+        /**
+         * Deserialization/addition of a 2D cubic spline from a string to this list.
+         *
+         * \param serial A QString containing the searialization of the 2D cubic spline.
+         * \return True, if the item could be deserialized and the model is not locked.
+         *         The serialization should be given as: dp0/dx, dp0/dy, p0_x, p0_y, ... , pN_x, pN_y, dpN/dx, dpN/dy
+         */
+        virtual bool deserialize_item(QXmlStreamReader& xmlReader);
     
         /**
          * Serialization the list of 2D cubic splines to an xml file.
@@ -264,7 +282,7 @@ class GRAIPE_FEATURES2D_EXPORT WeightedCubicSplineList2D
          * \return A QString containing the searialization of the 2D cubic spline.
          *         The serialization should be given as: weight, dp0/dx, dp0/dy, p0_x, p0_y, ... , pN_x, pN_y, dpN/dx, dpN/dy
          */
-        virtual QString serialize_item(unsigned int index) const;
+        virtual QString itemToCSV(unsigned int index) const;
     
         /**
          * Deserialization/addition of a 2D cubic spline from a string to this list.
@@ -272,7 +290,25 @@ class GRAIPE_FEATURES2D_EXPORT WeightedCubicSplineList2D
          * \param serial A QString containing the searialization of the 2D cubic spline.
          * \return True, if the item could be deserialized and the model is not locked.
          */
-        virtual bool deserialize_item(const QString & serial);
+        virtual bool itemFromCSV(const QString & serial);
+    
+        /**
+         * Serialization of one 2D cubic spline at a given list index to a string. This function will
+         * throw an error if the index is out of range.
+         *
+         * \param index The index of the 2D cubic spline to be serialized.
+         * \return A QString containing the searialization of the 2D cubic spline.
+         *         The serialization should be given as: weight, dp0/dx, dp0/dy, p0_x, p0_y, ... , pN_x, pN_y, dpN/dx, dpN/dy
+         */
+        virtual void serialize_item(unsigned int index, QXmlStreamWriter& xmlWriter) const;
+    
+        /**
+         * Deserialization/addition of a 2D cubic spline from a string to this list.
+         *
+         * \param serial A QString containing the searialization of the 2D cubic spline.
+         * \return True, if the item could be deserialized and the model is not locked.
+         */
+        virtual bool deserialize_item(QXmlStreamReader& xmlReader);
         
     protected:
         //The list of weights:

--- a/src/modules/features2d/cubicsplinelistviewcontroller.cxx
+++ b/src/modules/features2d/cubicsplinelistviewcontroller.cxx
@@ -143,7 +143,7 @@ QRectF CubicSplineList2DViewController::boundingRect() const
  *
  * \return Always: "CubicSplineList2DViewController"
  */
-QString CubicSplineList2DViewController::typeName() const
+QString CubicSplineList2DViewController::typeName()
 {
     return "CubicSplineList2DViewController";
 }
@@ -395,7 +395,7 @@ QRectF WeightedCubicSplineList2DViewController::boundingRect() const
  *
  * \return Always: "WeightedCubicSplineList2DViewController"
  */
-QString WeightedCubicSplineList2DViewController::typeName()  const
+QString WeightedCubicSplineList2DViewController::typeName()
 {
 	return "WeightedCubicSplineList2DViewController";
 }

--- a/src/modules/features2d/cubicsplinelistviewcontroller.cxx
+++ b/src/modules/features2d/cubicsplinelistviewcontroller.cxx
@@ -143,7 +143,7 @@ QRectF CubicSplineList2DViewController::boundingRect() const
  *
  * \return Always: "CubicSplineList2DViewController"
  */
-QString CubicSplineList2DViewController::typeName()
+QString CubicSplineList2DViewController::typeName() const
 {
     return "CubicSplineList2DViewController";
 }
@@ -395,7 +395,7 @@ QRectF WeightedCubicSplineList2DViewController::boundingRect() const
  *
  * \return Always: "WeightedCubicSplineList2DViewController"
  */
-QString WeightedCubicSplineList2DViewController::typeName()
+QString WeightedCubicSplineList2DViewController::typeName() const
 {
 	return "WeightedCubicSplineList2DViewController";
 }

--- a/src/modules/features2d/cubicsplinelistviewcontroller.hxx
+++ b/src/modules/features2d/cubicsplinelistviewcontroller.hxx
@@ -91,7 +91,7 @@ class GRAIPE_FEATURES2D_EXPORT CubicSplineList2DViewController
          *
          * \return Always: "CubicSplineList2DViewController"
          */
-        QString typeName() const;
+        static QString typeName();
         
     protected:
         /**
@@ -175,7 +175,7 @@ class GRAIPE_FEATURES2D_EXPORT WeightedCubicSplineList2DViewController
          *
          * \return Always: "WeightedCubicSplineList2DViewController"
          */
-        QString typeName() const;
+        static QString typeName();
     
         /**
          * Specialization of the update of  the parameters of this ViewController according to the current

--- a/src/modules/features2d/cubicsplinelistviewcontroller.hxx
+++ b/src/modules/features2d/cubicsplinelistviewcontroller.hxx
@@ -91,7 +91,7 @@ class GRAIPE_FEATURES2D_EXPORT CubicSplineList2DViewController
          *
          * \return Always: "CubicSplineList2DViewController"
          */
-        static QString typeName();
+        virtual QString typeName() const;
         
     protected:
         /**
@@ -175,7 +175,7 @@ class GRAIPE_FEATURES2D_EXPORT WeightedCubicSplineList2DViewController
          *
          * \return Always: "WeightedCubicSplineList2DViewController"
          */
-        static QString typeName();
+        virtual QString typeName() const;
     
         /**
          * Specialization of the update of  the parameters of this ViewController according to the current

--- a/src/modules/features2d/featurelist.cxx
+++ b/src/modules/features2d/featurelist.cxx
@@ -220,9 +220,10 @@ void PointFeatureList2D::serialize_content(QXmlStreamWriter& xmlWriter) const
  *
  * \param in The QIODevice, where we will read from.
  */
-bool PointFeatureList2D::deserialize_content(QIODevice& in)
+bool PointFeatureList2D::deserialize_content(QXmlStreamReader& xmlReader)
 {
-    if (locked())
+ //TODO!!!
+/**   if (locked())
         return false;
         
     //Read in header line and then throw it away immideately
@@ -243,6 +244,8 @@ bool PointFeatureList2D::deserialize_content(QIODevice& in)
         }
     }
     return true;
+    */
+    return false;
 }
 
 

--- a/src/modules/features2d/featurelist.cxx
+++ b/src/modules/features2d/featurelist.cxx
@@ -193,7 +193,7 @@ bool PointFeatureList2D::deserialize_item(const QString & serial)
 }
 
 /**
- * Serialize the complete content of the featurelist to a QIODevice.
+ * Serialize the complete content of the featurelist to an xml file.
  * Mainly prints:
  *   item_header()
  * and for each feature:
@@ -215,11 +215,11 @@ void PointFeatureList2D::serialize_content(QXmlStreamWriter& xmlWriter) const
 }
 
 /**
- * Deserializion of a  feature list from a QIODevice.
+ * Deserialization of a  feature list from an xml file.
  * The first line is the header as given in item_header(), which is ignored however.
  * Each following line has to be one valide feature serialization.
  *
- * \param in The QIODevice, where we will read from.
+ * \param xmlReader The QXmlStreamReader, where we will read from.
  */
 bool PointFeatureList2D::deserialize_content(QXmlStreamReader& xmlReader)
 {

--- a/src/modules/features2d/featurelist.cxx
+++ b/src/modules/features2d/featurelist.cxx
@@ -203,14 +203,15 @@ bool PointFeatureList2D::deserialize_item(const QString & serial)
  */
 void PointFeatureList2D::serialize_content(QXmlStreamWriter& xmlWriter) const
 {
-//TODO
-/*    write_on_device(item_header(), out);
+    xmlWriter.writeTextElement("Legend", item_header());
     
 	for(unsigned int i=0; i < size(); ++i)
     {
-		write_on_device("\n" + serialize_item(i), out);
-	}
-    */
+        xmlWriter.writeStartElement("Feature");
+        xmlWriter.writeAttribute("ID", QString::number(i));
+            xmlWriter.writeCharacters(serialize_item(i));
+        xmlWriter.writeEndElement();
+    }
 }
 
 /**
@@ -222,30 +223,27 @@ void PointFeatureList2D::serialize_content(QXmlStreamWriter& xmlWriter) const
  */
 bool PointFeatureList2D::deserialize_content(QXmlStreamReader& xmlReader)
 {
- //TODO!!!
-/**   if (locked())
+    if (locked())
         return false;
-        
-    //Read in header line and then throw it away immideately
-    if(!in.atEnd())
-        in.readLine();
-    
+
     //Clean up
 	clear();
     updateModel();
     
     //Read the entries
-    while(!in.atEnd())
+    while(xmlReader.readNextStartElement())
     {
-        QString line(in.readLine());
-        if(!line.isEmpty() && !line.startsWith(";"))
+        if(xmlReader.name() == "Feature")
         {
-           deserialize_item(line);
+            if(!deserialize_item(xmlReader.readElementText()))
+                return false;
+        }
+        else
+        {
+            xmlReader.skipCurrentElement();
         }
     }
     return true;
-    */
-    return false;
 }
 
 

--- a/src/modules/features2d/featurelist.cxx
+++ b/src/modules/features2d/featurelist.cxx
@@ -52,7 +52,7 @@ PointFeatureList2D::PointFeatureList2D()
  *
  * \return Always "PointFeatureList2D"
  */
-QString PointFeatureList2D::typeName() const
+QString PointFeatureList2D::typeName()
 {
 	return "PointFeatureList2D";
 }
@@ -144,7 +144,7 @@ void PointFeatureList2D::removeFeature(unsigned int index)
  * 
  * \return Always: "pos_x, pos_y"
  */
-QString PointFeatureList2D::item_header() const
+QString PointFeatureList2D::csvHeader() const
 {
 	return "pos_x, pos_y";
 }
@@ -156,7 +156,7 @@ QString PointFeatureList2D::item_header() const
  * \param index Index of the feature to be serialized.
  * \return QString of the feature, ordered as: x, y.
  */
- QString PointFeatureList2D::serialize_item(unsigned int index) const
+QString PointFeatureList2D::itemToCSV(unsigned int index) const
 {
 	return   QString::number(m_points[index].x(), 'g', 10) + ", "
            + QString::number(m_points[index].y(), 'g', 10);
@@ -169,7 +169,7 @@ QString PointFeatureList2D::item_header() const
  * \return True, if the item could be deserialized and the model is not locked.
  *         The serialization should be given as: x, y
  */
-bool PointFeatureList2D::deserialize_item(const QString & serial)
+bool PointFeatureList2D::itemFromCSV(const QString & serial)
 {
     if(locked())
         return false;
@@ -191,11 +191,65 @@ bool PointFeatureList2D::deserialize_item(const QString & serial)
 	}
 	return false;
 }
+		
 
+/**
+ * Serialization of a single feature inside the list at a given index.
+ * The feature will be serialized by means of comma separated values.
+ * 
+ * \param index Index of the feature to be serialized.
+ * \return QString of the feature, namely "x, y"
+ */
+void PointFeatureList2D::serialize_item(unsigned int index, QXmlStreamWriter& xmlWriter) const
+{
+    xmlWriter.writeTextElement("x", QString::number(m_points[index].x(), 'g', 10));
+    xmlWriter.writeTextElement("y", QString::number(m_points[index].y(), 'g', 10));
+}
+
+/**
+ * Deserialization/addition of a feature from a string to this list.
+ * Does nothing if the model is locked.
+ *
+ * \param serial A QString containing the serialization of the feature.
+ * \return True, if the item could be deserialized and the model is not locked.
+ *         The serialization is ordered as: x, y
+ */
+bool PointFeatureList2D::deserialize_item(QXmlStreamReader& xmlReader)
+{
+    PointType new_p;
+    
+    //Read two start elements
+    for(int i=0; i<2; ++i)
+    {
+        if (xmlReader.readNextStartElement())
+        {
+            if(xmlReader.name() == "x")
+            {
+                new_p.setX(xmlReader.readElementText().toFloat());
+            }
+            else if (xmlReader.name() == "y")
+            {
+                new_p.setY(xmlReader.readElementText().toFloat());
+            }
+            else
+            {
+                qWarning() << "Searching for x and y tags, but found:" << xmlReader.name();
+                return false;
+            }
+        }
+        else
+        {
+            qWarning() << "Did not find at least two start elements";
+            return false;
+        }
+    }
+    m_points.push_back(new_p);
+    return true;
+}
 /**
  * Serialize the complete content of the featurelist to an xml file.
  * Mainly prints:
- *   item_header()
+ *   csvHeader
  * and for each feature:
  *   newline + serialize_item().
  *
@@ -203,20 +257,18 @@ bool PointFeatureList2D::deserialize_item(const QString & serial)
  */
 void PointFeatureList2D::serialize_content(QXmlStreamWriter& xmlWriter) const
 {
-    xmlWriter.writeTextElement("Legend", item_header());
-    
 	for(unsigned int i=0; i < size(); ++i)
     {
         xmlWriter.writeStartElement("Feature");
         xmlWriter.writeAttribute("ID", QString::number(i));
-            xmlWriter.writeCharacters(serialize_item(i));
+            serialize_item(i, xmlWriter);
         xmlWriter.writeEndElement();
     }
 }
 
 /**
  * Deserialization of a  feature list from an xml file.
- * The first line is the header as given in item_header(), which is ignored however.
+ * The first line is the header as given in csvHeader, which is ignored however.
  * Each following line has to be one valide feature serialization.
  *
  * \param xmlReader The QXmlStreamReader, where we will read from.
@@ -235,13 +287,28 @@ bool PointFeatureList2D::deserialize_content(QXmlStreamReader& xmlReader)
     {
         if(xmlReader.name() == "Feature")
         {
-            if(!deserialize_item(xmlReader.readElementText()))
+            if(!deserialize_item(xmlReader))
                 return false;
         }
         else
         {
-            xmlReader.skipCurrentElement();
+            qWarning() << "Found non 'Feature' tag in serialization of elements";
+            return false;
         }
+        //Read until </Feature> comes...
+        while(true)
+        {
+            if(!xmlReader.readNext())
+            {
+                return false;
+            }
+            
+            if(xmlReader.isEndElement() && xmlReader.name() == "Feature")
+            {
+                break;
+            }
+        }
+
     }
     return true;
 }
@@ -261,7 +328,7 @@ WeightedPointFeatureList2D::WeightedPointFeatureList2D()
  *
  * \return Always "WeightedPointFeatureList2D"
  */
-QString WeightedPointFeatureList2D::typeName() const
+QString WeightedPointFeatureList2D::typeName()
 {
 	return "WeightedPointFeatureList2D";
 }
@@ -360,9 +427,9 @@ void WeightedPointFeatureList2D::removeFeature(unsigned int index)
  * 
  * \return Always: "pos_x, pos_y, weight"
  */
-QString WeightedPointFeatureList2D::item_header() const
+QString WeightedPointFeatureList2D::csvHeader() const
 {
-	return PointFeatureList2D::item_header() + ", weight";
+	return PointFeatureList2D::csvHeader() + ", weight";
 }
     
 /**
@@ -372,9 +439,9 @@ QString WeightedPointFeatureList2D::item_header() const
  * \param index Index of the weighted feature to be serialized.
  * \return QString of the weighted feature, ordered as: x, y, weight.
  */
-QString WeightedPointFeatureList2D::serialize_item(unsigned int index) const
+QString WeightedPointFeatureList2D::itemToCSV(unsigned int index) const
 {
-	return PointFeatureList2D::serialize_item(index) + ", " + QString::number(m_weights[index], 'g', 10);
+	return PointFeatureList2D::itemToCSV(index) + ", " + QString::number(m_weights[index], 'g', 10);
 }
 
 /**
@@ -384,7 +451,7 @@ QString WeightedPointFeatureList2D::serialize_item(unsigned int index) const
  * \return True, if the item could be deserialized and the model is not locked.
  *         The serialization should be given as: x, y, weight
  */
-bool WeightedPointFeatureList2D::deserialize_item(const QString & serial)
+bool WeightedPointFeatureList2D::itemFromCSV(const QString & serial)
 {
     if(locked())
         return false;
@@ -397,7 +464,7 @@ bool WeightedPointFeatureList2D::deserialize_item(const QString & serial)
 		try
         {
             m_weights.push_back(values[2].toFloat());
-            PointFeatureList2D::deserialize_item(serial);
+            PointFeatureList2D::itemFromCSV(serial);
 			return true;
 		}
 		catch(...)
@@ -406,6 +473,48 @@ bool WeightedPointFeatureList2D::deserialize_item(const QString & serial)
 		}
 	}
 	return false;
+}
+/**
+ * Serialization of a single weighted feature inside the list at a given index.
+ * The weighted feature will be serialized by means of comma separated values.
+ * 
+ * \param index Index of the weighted feature to be serialized.
+ * \return QString of the weighted feature, ordered as: x, y, weight.
+ */
+void WeightedPointFeatureList2D::serialize_item(unsigned int index, QXmlStreamWriter& xmlWriter) const
+{
+	PointFeatureList2D::serialize_item(index, xmlWriter);
+    xmlWriter.writeTextElement("weight", QString::number(m_weights[index], 'g', 10));
+}
+
+/**
+ * Deserialization/addition of a weighted feature from a string to this list.
+ *
+ * \param serial A QString containing the serialization of the weighted feature.
+ * \return True, if the item could be deserialized and the model is not locked.
+ *         The serialization should be given as: x, y, weight
+ */
+bool WeightedPointFeatureList2D::deserialize_item(QXmlStreamReader& xmlReader)
+{
+    if(locked())
+        return false;
+    
+    if(!PointFeatureList2D::deserialize_item(xmlReader))
+    {
+        return false;
+    }
+	
+    if(     xmlReader.readNextStartElement()
+        &&  xmlReader.name() == "weight")
+    {
+        m_weights.push_back(xmlReader.readElementText().toFloat());
+        return true;
+    }
+    else
+    {
+        qWarning() << "Did not find a start element for feature weight";
+        return false;
+    }
 }
 
 
@@ -423,7 +532,7 @@ EdgelFeatureList2D::EdgelFeatureList2D()
  *
  * \return Always "EdgelFeatureList2D"
  */
-QString EdgelFeatureList2D::typeName() const
+QString EdgelFeatureList2D::typeName()
 {
 	return "EdgelFeatureList2D";
 }
@@ -549,9 +658,9 @@ void EdgelFeatureList2D::removeFeature(unsigned int index)
  * 
  * \return Always: "pos_x, pos_y, weight, orientation"
  */
-QString EdgelFeatureList2D::item_header() const
+QString EdgelFeatureList2D::csvHeader() const
 {
-	return WeightedPointFeatureList2D::item_header() + ", orientation";
+	return WeightedPointFeatureList2D::csvHeader() + ", orientation";
 }
 
 /**
@@ -561,9 +670,9 @@ QString EdgelFeatureList2D::item_header() const
  * \param index Index of the edgel feature to be serialized.
  * \return QString of the edgel feature, ordered  as: x, y, weight, orientation.
  */
-QString EdgelFeatureList2D::serialize_item(unsigned int index) const
+QString EdgelFeatureList2D::itemToCSV(unsigned int index) const
 {
-	return WeightedPointFeatureList2D::serialize_item(index) + ", " + QString::number(m_orientations[index], 'g', 10);
+	return WeightedPointFeatureList2D::itemToCSV(index) + ", " + QString::number(m_orientations[index], 'g', 10);
 }
 
 /**
@@ -573,7 +682,7 @@ QString EdgelFeatureList2D::serialize_item(unsigned int index) const
  * \return True, if the item could be deserialized and the model is not locked.
  *         The serialization should be given as: x, y, weight, orientation
  */
-bool EdgelFeatureList2D::deserialize_item(const QString & serial)
+bool EdgelFeatureList2D::itemFromCSV(const QString & serial)
 {	
     if(locked())
         return false;
@@ -585,7 +694,7 @@ bool EdgelFeatureList2D::deserialize_item(const QString & serial)
 		try
         {
             m_orientations.push_back(values[3].toFloat());
-            WeightedPointFeatureList2D::deserialize_item(serial);
+            WeightedPointFeatureList2D::itemFromCSV(serial);
 			return true;
 		}
 		catch(...)
@@ -594,6 +703,49 @@ bool EdgelFeatureList2D::deserialize_item(const QString & serial)
 		}
 	}
 	return false;
+}
+
+/**
+ * Serialization of a single edgel feature inside the list at a given index.
+ * The edgelfeature will be serialized by means of comma separated values.
+ * 
+ * \param index Index of the edgel feature to be serialized.
+ * \return QString of the edgel feature, ordered  as: x, y, weight, orientation.
+ */
+void EdgelFeatureList2D::serialize_item(unsigned int index, QXmlStreamWriter& xmlWriter) const
+{
+	WeightedPointFeatureList2D::serialize_item(index, xmlWriter);
+    xmlWriter.writeTextElement("orientation", QString::number(m_orientations[index], 'g', 10));
+}
+
+/**
+ * Deserialization/addition of a edgel feature from a string to this list.
+ *
+ * \param serial A QString containing the serialization of the edgel feature.
+ * \return True, if the item could be deserialized and the model is not locked.
+ *         The serialization should be given as: x, y, weight, orientation
+ */
+bool EdgelFeatureList2D::deserialize_item(QXmlStreamReader& xmlReader)
+{	
+    if(locked())
+        return false;
+    
+    if(!WeightedPointFeatureList2D::deserialize_item(xmlReader))
+    {
+        return false;
+    }
+	
+    if(     xmlReader.readNextStartElement()
+        &&  xmlReader.name() == "orientation")
+    {
+        m_orientations.push_back(xmlReader.readElementText().toFloat());
+        return true;
+    }
+    else
+    {
+        qWarning() << "Did not find a start element for feature orientation";
+        return false;
+    }
 }
 
 
@@ -612,7 +764,7 @@ SIFTFeatureList2D::SIFTFeatureList2D()
  *
  * \return Always "SIFTFeatureList2D"
  */
-QString SIFTFeatureList2D::typeName() const
+QString SIFTFeatureList2D::typeName()
 {
 	return "SIFTFeatureList2D";
 }
@@ -785,9 +937,9 @@ void SIFTFeatureList2D::removeFeature(unsigned int index)
  * 
  * \return Always: "x, y, weight, orientation, scale, descr_0, ..., descr_N"
  */
-QString SIFTFeatureList2D::item_header() const
+QString SIFTFeatureList2D::csvHeader() const
 {
-	return EdgelFeatureList2D::item_header() + ", scale, descr_0, ..., descr_N";
+	return EdgelFeatureList2D::csvHeader() + ", scale, descr_0, ..., descr_N";
 }
 
 /**
@@ -797,9 +949,9 @@ QString SIFTFeatureList2D::item_header() const
  * \param index Index of the SIFT feature to be serialized.
  * \return QString of the edgel feature, ordered  as: x, y, weight, orientation, scale, descr_0, ..., descr_N.
  */
-QString SIFTFeatureList2D::serialize_item(unsigned int index) const
+QString SIFTFeatureList2D::itemToCSV(unsigned int index) const
 {
-	QString result = QString("%1, %2").arg(EdgelFeatureList2D::serialize_item(index)).arg(m_scales[index]);
+	QString result = QString("%1, %2").arg(EdgelFeatureList2D::itemToCSV(index)).arg(m_scales[index]);
     
     for(unsigned int i=0; i< (unsigned int)m_descriptors[index].size(); ++i)
     {
@@ -816,7 +968,7 @@ QString SIFTFeatureList2D::serialize_item(unsigned int index) const
  * \return True, if the item could be deserialized and the model is not locked.
  *         The serialization should be given as: x, y, weight, orientation, scale, descr_0, ..., descr_N.
  */
-bool SIFTFeatureList2D::deserialize_item(const QString & serial)
+bool SIFTFeatureList2D::itemFromCSV(const QString & serial)
 {
     if(locked())
         return false;
@@ -843,7 +995,7 @@ bool SIFTFeatureList2D::deserialize_item(const QString & serial)
             
             m_descriptors.push_back(desc);
             
-            EdgelFeatureList2D::deserialize_item(serial);
+            EdgelFeatureList2D::itemFromCSV(serial);
 			
 			return true;
 		}
@@ -853,6 +1005,93 @@ bool SIFTFeatureList2D::deserialize_item(const QString & serial)
 		}
 	}
 	return false;
+}
+
+/**
+ * Serialization of a single SIFT feature inside the list at a given index.
+ * The SIFT will be serialized by means of comma separated values.
+ * 
+ * \param index Index of the SIFT feature to be serialized.
+ * \return QString of the edgel feature, ordered  as: x, y, weight, orientation, scale, descr_0, ..., descr_N.
+ */
+void SIFTFeatureList2D::serialize_item(unsigned int index, QXmlStreamWriter& xmlWriter) const
+{
+	EdgelFeatureList2D::serialize_item(index, xmlWriter);
+    
+    xmlWriter.writeTextElement("scale", QString::number(m_scales[index], 'g', 10));
+    
+    xmlWriter.writeStartElement("descriptor");
+    xmlWriter.writeAttribute("size", QString::number(m_descriptors[index].size()));
+    
+    for(unsigned int i=0; i< (unsigned int)m_descriptors[index].size(); ++i)
+    {
+		xmlWriter.writeStartElement("value");
+        xmlWriter.writeAttribute("ID", QString::number(i));
+            xmlWriter.writeCharacters(QString::number((m_descriptors[index])[i], 'g', 10));
+        xmlWriter.writeEndElement();
+	}
+}
+    
+/**
+ * Deserialization/addition of a SIFT feature from a string to this list.
+ *
+ * \param serial A QString containing the serialization of the SIFT feature.
+ * \return True, if the item could be deserialized and the model is not locked.
+ *         The serialization should be given as: x, y, weight, orientation, scale, descr_0, ..., descr_N.
+ */
+bool SIFTFeatureList2D::deserialize_item(QXmlStreamReader& xmlReader)
+{
+    if(locked())
+        return false;
+    
+    if(!EdgelFeatureList2D::deserialize_item(xmlReader))
+    {
+        return false;
+    }
+    //Read two more starting tags
+	for(int i=0; i!=2; i++)
+    {
+        if(xmlReader.readNextStartElement())
+        {
+            if(xmlReader.name() == "scale")
+            {
+                m_scales.push_back(xmlReader.readElementText().toFloat());
+            }
+            else if(   xmlReader.name() == "descriptor"
+                    && xmlReader.attributes().hasAttribute("size"))
+            {
+                int d_size = xmlReader.attributes().value("size").toInt();
+                QVector<float> desc(d_size);
+                
+                //Read the descriptor
+                for(int d_i=0; d_i!=d_size; d_i++)
+                {
+                    if(     xmlReader.readNextStartElement()
+                        &&  xmlReader.name() == "value")
+                    {
+                        desc[d_i] = xmlReader.readElementText().toFloat();
+                    }
+                    else
+                    {
+                        qWarning() << "Did not find enough descriptor fields, needed"  << xmlReader.attributes().value("size") << " stopped at: " << d_i ;
+                        return false;
+                    }
+                }
+                m_descriptors.push_back(desc);
+            }
+            else
+            {
+                qWarning() << "Did find a different start element for SIFT features:" <<  xmlReader.name();
+                return false;
+            }
+        }
+        else
+        {
+            qWarning() << "Did not find at least two more start element for SIFT features";
+            return false;
+        }
+    }
+    return true;
 }
 
 } //End of namespace graipe

--- a/src/modules/features2d/featurelist.cxx
+++ b/src/modules/features2d/featurelist.cxx
@@ -201,14 +201,16 @@ bool PointFeatureList2D::deserialize_item(const QString & serial)
  *
  * \param out The output device for serialization.
  */
-void PointFeatureList2D::serialize_content(QIODevice & out) const
+void PointFeatureList2D::serialize_content(QXmlStreamWriter& xmlWriter) const
 {
-    write_on_device(item_header(), out);
+//TODO
+/*    write_on_device(item_header(), out);
     
 	for(unsigned int i=0; i < size(); ++i)
     {
 		write_on_device("\n" + serialize_item(i), out);
 	}
+    */
 }
 
 /**

--- a/src/modules/features2d/featurelist.cxx
+++ b/src/modules/features2d/featurelist.cxx
@@ -52,7 +52,7 @@ PointFeatureList2D::PointFeatureList2D()
  *
  * \return Always "PointFeatureList2D"
  */
-QString PointFeatureList2D::typeName()
+QString PointFeatureList2D::typeName() const
 {
 	return "PointFeatureList2D";
 }
@@ -328,7 +328,7 @@ WeightedPointFeatureList2D::WeightedPointFeatureList2D()
  *
  * \return Always "WeightedPointFeatureList2D"
  */
-QString WeightedPointFeatureList2D::typeName()
+QString WeightedPointFeatureList2D::typeName() const
 {
 	return "WeightedPointFeatureList2D";
 }
@@ -532,7 +532,7 @@ EdgelFeatureList2D::EdgelFeatureList2D()
  *
  * \return Always "EdgelFeatureList2D"
  */
-QString EdgelFeatureList2D::typeName()
+QString EdgelFeatureList2D::typeName() const
 {
 	return "EdgelFeatureList2D";
 }
@@ -764,7 +764,7 @@ SIFTFeatureList2D::SIFTFeatureList2D()
  *
  * \return Always "SIFTFeatureList2D"
  */
-QString SIFTFeatureList2D::typeName()
+QString SIFTFeatureList2D::typeName() const
 {
 	return "SIFTFeatureList2D";
 }

--- a/src/modules/features2d/featurelist.hxx
+++ b/src/modules/features2d/featurelist.hxx
@@ -142,7 +142,7 @@ class GRAIPE_FEATURES2D_EXPORT PointFeatureList2D
 		virtual bool deserialize_item(const QString& serial);
     
         /**
-         * Serialize the complete content of the featurelist to a QIODevice.
+         * Serialize the complete content of the featurelist to an xml file.
          * Mainly prints:
          *   item_header()
          * and for each feature:
@@ -153,12 +153,12 @@ class GRAIPE_FEATURES2D_EXPORT PointFeatureList2D
 		void serialize_content(QXmlStreamWriter& xmlWriter) const;
     
         /**
-         * Deserializion of a  feature list from a QIODevice.
+         * Deserialization of a  feature list from an xml file.
          * The first line is the header as given in item_header(), which is ignored however.
          * Each following line has to be one valide feature serialization.
          * Does nothing if the model is locked.
          *
-         * \param in The QIODevice, where we will read from.
+         * \param xmlReader The QXmlStreamReader, where we will read from.
          */
 		bool deserialize_content(QXmlStreamReader& xmlReader);
 	

--- a/src/modules/features2d/featurelist.hxx
+++ b/src/modules/features2d/featurelist.hxx
@@ -160,7 +160,7 @@ class GRAIPE_FEATURES2D_EXPORT PointFeatureList2D
          *
          * \param in The QIODevice, where we will read from.
          */
-		bool deserialize_content(QIODevice& in);
+		bool deserialize_content(QXmlStreamReader& xmlReader);
 	
 	protected:
 		//The pointlist

--- a/src/modules/features2d/featurelist.hxx
+++ b/src/modules/features2d/featurelist.hxx
@@ -66,7 +66,7 @@ class GRAIPE_FEATURES2D_EXPORT PointFeatureList2D
          *
          * \return Always "PointFeatureList2D"
          */
-		static QString typeName();
+		virtual QString typeName() const;
 		
         /**
          * Returns the number of features in this list.
@@ -209,7 +209,7 @@ class GRAIPE_FEATURES2D_EXPORT WeightedPointFeatureList2D
          *
          * \return Always "WeightedPointFeatureList2D"
          */
-        static QString typeName();
+        virtual QString typeName() const;
 		
         /**
          * Completely erases this list of weighted features. Does nothing if the list is locked.
@@ -335,7 +335,7 @@ class GRAIPE_FEATURES2D_EXPORT EdgelFeatureList2D
          *
          * \return Always "EdgelFeatureList2D"
          */
-		static QString typeName();
+		virtual QString typeName() const;
 	
         /**
          * Completely erases this list of edgel features. Does nothing if the list is locked.
@@ -485,7 +485,7 @@ class GRAIPE_FEATURES2D_EXPORT SIFTFeatureList2D
          *
          * \return Always "SIFTFeatureList2D"
          */
-		static QString typeName();
+		virtual QString typeName() const;
 	
         /**
          * Completely erases this list of SIFT features. Does nothing if the list is locked.

--- a/src/modules/features2d/featurelist.hxx
+++ b/src/modules/features2d/featurelist.hxx
@@ -150,7 +150,7 @@ class GRAIPE_FEATURES2D_EXPORT PointFeatureList2D
          *
          * \param out The output device for serialization.
          */
-		void serialize_content(QIODevice& out) const;
+		void serialize_content(QXmlStreamWriter& xmlWriter) const;
     
         /**
          * Deserializion of a  feature list from a QIODevice.

--- a/src/modules/features2d/featurelist.hxx
+++ b/src/modules/features2d/featurelist.hxx
@@ -66,7 +66,7 @@ class GRAIPE_FEATURES2D_EXPORT PointFeatureList2D
          *
          * \return Always "PointFeatureList2D"
          */
-		QString typeName() const;
+		static QString typeName();
 		
         /**
          * Returns the number of features in this list.
@@ -120,7 +120,7 @@ class GRAIPE_FEATURES2D_EXPORT PointFeatureList2D
          * 
          * \return Always: "pos_x, pos_y"
          */
-		virtual QString item_header() const;
+		virtual QString csvHeader() const;
         
         /**
          * Serialization of a single feature inside the list at a given index.
@@ -129,7 +129,7 @@ class GRAIPE_FEATURES2D_EXPORT PointFeatureList2D
          * \param index Index of the feature to be serialized.
          * \return QString of the feature, namely "x, y"
          */
-		virtual QString serialize_item(unsigned int index) const;
+		virtual QString itemToCSV(unsigned int index) const;
         
         /**
          * Deserialization/addition of a feature from a string to this list.
@@ -139,12 +139,31 @@ class GRAIPE_FEATURES2D_EXPORT PointFeatureList2D
          * \return True, if the item could be deserialized and the model is not locked.
          *         The serialization is ordered as: x, y
          */
-		virtual bool deserialize_item(const QString& serial);
+		virtual bool itemFromCSV(const QString& serial);
+        
+        /**
+         * Serialization of a single feature inside the list at a given index.
+         * The feature will be serialized by means of comma separated values.
+         * 
+         * \param index Index of the feature to be serialized.
+         * \return QString of the feature, namely "x, y"
+         */
+		virtual void serialize_item(unsigned int index, QXmlStreamWriter& xmlWriter) const;
+        
+        /**
+         * Deserialization/addition of a feature from a string to this list.
+         * Does nothing if the model is locked.
+         *
+         * \param serial A QString containing the serialization of the feature.
+         * \return True, if the item could be deserialized and the model is not locked.
+         *         The serialization is ordered as: x, y
+         */
+		virtual bool deserialize_item(QXmlStreamReader& xmlReader);
     
         /**
          * Serialize the complete content of the featurelist to an xml file.
          * Mainly prints:
-         *   item_header()
+         *   csvHeader
          * and for each feature:
          *   newline + serialize_item().
          *
@@ -154,7 +173,7 @@ class GRAIPE_FEATURES2D_EXPORT PointFeatureList2D
     
         /**
          * Deserialization of a  feature list from an xml file.
-         * The first line is the header as given in item_header(), which is ignored however.
+         * The first line is the header as given in csvHeader, which is ignored however.
          * Each following line has to be one valide feature serialization.
          * Does nothing if the model is locked.
          *
@@ -190,7 +209,7 @@ class GRAIPE_FEATURES2D_EXPORT WeightedPointFeatureList2D
          *
          * \return Always "WeightedPointFeatureList2D"
          */
-        QString typeName() const;
+        static QString typeName();
 		
         /**
          * Completely erases this list of weighted features. Does nothing if the list is locked.
@@ -247,7 +266,7 @@ class GRAIPE_FEATURES2D_EXPORT WeightedPointFeatureList2D
          * 
          * \return Always: "pos_x, pos_y, weight"
          */
-		QString item_header() const;
+		QString csvHeader() const;
     
         /**
          * Serialization of a single weighted feature inside the list at a given index.
@@ -256,7 +275,7 @@ class GRAIPE_FEATURES2D_EXPORT WeightedPointFeatureList2D
          * \param index Index of the weighted feature to be serialized.
          * \return QString of the weighted feature, ordered as: x, y, weight.
          */
-		QString serialize_item(unsigned int index) const;
+		virtual QString itemToCSV(unsigned int index) const;
     
         /**
          * Deserialization/addition of a weighted feature from a string to this list.
@@ -266,7 +285,26 @@ class GRAIPE_FEATURES2D_EXPORT WeightedPointFeatureList2D
          * \return True, if the item could be deserialized and the model is not locked.
          *         The serialization should be given as: x, y, weight
          */
-		bool deserialize_item(const QString& serial);
+		bool itemFromCSV(const QString& serial);
+    
+        /**
+         * Serialization of a single weighted feature inside the list at a given index.
+         * The weighted feature will be serialized by means of comma separated values.
+         * 
+         * \param index Index of the weighted feature to be serialized.
+         * \return QString of the weighted feature, ordered as: x, y, weight.
+         */
+		void serialize_item(unsigned int index, QXmlStreamWriter& xmlWriter) const;
+    
+        /**
+         * Deserialization/addition of a weighted feature from a string to this list.
+         * Does nothing if the model is locked.
+         *
+         * \param serial A QString containing the serialization of the weighted feature.
+         * \return True, if the item could be deserialized and the model is not locked.
+         *         The serialization should be given as: x, y, weight
+         */
+		bool deserialize_item(QXmlStreamReader& xmlReader);
     
 		
 	protected:
@@ -297,7 +335,7 @@ class GRAIPE_FEATURES2D_EXPORT EdgelFeatureList2D
          *
          * \return Always "EdgelFeatureList2D"
          */
-		QString typeName() const;
+		static QString typeName();
 	
         /**
          * Completely erases this list of edgel features. Does nothing if the list is locked.
@@ -380,26 +418,45 @@ class GRAIPE_FEATURES2D_EXPORT EdgelFeatureList2D
          * 
          * \return Always: "pos_x, pos_y, weight, orientation"
          */
-		QString item_header() const;
+		QString csvHeader() const;
     
         /**
-         * Serialization of a single edgel feature inside the list at a given index.
-         * The edgelfeature will be serialized by means of comma separated values.
+         * Serialization of a single weighted feature inside the list at a given index.
+         * The weighted feature will be serialized by means of comma separated values.
          * 
-         * \param index Index of the edgel feature to be serialized.
-         * \return QString of the edgel feature, ordered  as: x, y, weight, orientation.
+         * \param index Index of the weighted feature to be serialized.
+         * \return QString of the weighted feature, ordered as: x, y, weight, orientation.
          */
-		QString serialize_item(unsigned int index) const;
+		virtual QString itemToCSV(unsigned int index) const;
     
         /**
-         * Deserialization/addition of a edgel feature from a string to this list.
+         * Deserialization/addition of a weighted feature from a string to this list.
          * Does nothing if the model is locked.
          *
-         * \param serial A QString containing the serialization of the edgel feature.
+         * \param serial A QString containing the serialization of the weighted feature.
          * \return True, if the item could be deserialized and the model is not locked.
          *         The serialization should be given as: x, y, weight, orientation
          */
-		bool deserialize_item(const QString& serial);
+		bool itemFromCSV(const QString& serial);
+    
+        /**
+         * Serialization of a single weighted feature inside the list at a given index.
+         * The weighted feature will be serialized by means of comma separated values.
+         * 
+         * \param index Index of the weighted feature to be serialized.
+         * \return QString of the weighted feature, ordered as: x, y, weight, orientation.
+         */
+		void serialize_item(unsigned int index, QXmlStreamWriter& xmlWriter) const;
+    
+        /**
+         * Deserialization/addition of a weighted feature from a string to this list.
+         * Does nothing if the model is locked.
+         *
+         * \param serial A QString containing the serialization of the weighted feature.
+         * \return True, if the item could be deserialized and the model is not locked.
+         *         The serialization should be given as: x, y, weight, orientation
+         */
+		bool deserialize_item(QXmlStreamReader& xmlReader);
 		
 	protected:
         //Aditional orientations
@@ -428,7 +485,7 @@ class GRAIPE_FEATURES2D_EXPORT SIFTFeatureList2D
          *
          * \return Always "SIFTFeatureList2D"
          */
-		QString typeName() const;
+		static QString typeName();
 	
         /**
          * Completely erases this list of SIFT features. Does nothing if the list is locked.
@@ -541,7 +598,7 @@ class GRAIPE_FEATURES2D_EXPORT SIFTFeatureList2D
          * 
          * \return Always: "x, y, weight, orientation, scale, descr_0, ..., descr_N"
          */
-		QString item_header() const;
+		QString csvHeader() const;
     
         /**
          * Serialization of a single SIFT feature inside the list at a given index.
@@ -550,7 +607,7 @@ class GRAIPE_FEATURES2D_EXPORT SIFTFeatureList2D
          * \param index Index of the SIFT feature to be serialized.
          * \return QString of the edgel feature, ordered  as: x, y, weight, orientation, scale, descr_0, ..., descr_N.
          */
-		QString serialize_item(unsigned int index) const;
+		QString itemToCSV(unsigned int index) const;
     
         /**
          * Deserialization/addition of a SIFT feature from a string to this list.
@@ -559,7 +616,25 @@ class GRAIPE_FEATURES2D_EXPORT SIFTFeatureList2D
          * \return True, if the item could be deserialized and the model is not locked.
          *         The serialization should be given as: x, y, weight, orientation, scale, descr_0, ..., descr_N.
          */
-		bool deserialize_item(const QString& serial);
+		bool itemFromCSV(const QString& serial);
+    
+        /**
+         * Serialization of a single SIFT feature inside the list at a given index.
+         * The SIFT will be serialized by means of comma separated values.
+         * 
+         * \param index Index of the SIFT feature to be serialized.
+         * \return QString of the edgel feature, ordered  as: x, y, weight, orientation, scale, descr_0, ..., descr_N.
+         */
+		void serialize_item(unsigned int index, QXmlStreamWriter& xmlWriter) const;
+    
+        /**
+         * Deserialization/addition of a SIFT feature from a string to this list.
+         *
+         * \param serial A QString containing the serialization of the SIFT feature.
+         * \return True, if the item could be deserialized and the model is not locked.
+         *         The serialization should be given as: x, y, weight, orientation, scale, descr_0, ..., descr_N.
+         */
+		bool deserialize_item(QXmlStreamReader& xmlReader);
 		
 	protected:
         //Additional scales and feature descriptors

--- a/src/modules/features2d/featurelistviewcontroller.cxx
+++ b/src/modules/features2d/featurelistviewcontroller.cxx
@@ -211,7 +211,7 @@ void PointFeatureList2DViewController::hoverMoveEvent(QGraphicsSceneHoverEvent *
             }
             else
             {
-                features_in_reach =		QString("<table align='center' border='1'><tr> <td>Idx</td> <td>x</td> <td>y</td> <td>dist</td> </tr>")
+                features_in_reach =		QString("<table><tr> <th>Idx</th> <th>x</th> <th>y</th> <th>dist</th> </tr>")
                 +	features_in_reach
                 +	QString("</table>");
             }
@@ -219,7 +219,7 @@ void PointFeatureList2DViewController::hoverMoveEvent(QGraphicsSceneHoverEvent *
             emit updateStatusText(features->shortName() + QString("[%1,%2]").arg(x).arg(y));
             emit updateStatusDescription(	QString("<b>Mouse moved over Object: </b><br/><i>") 
                                          +	features->shortName()
-                                         +	QString("</i><br/>at position [%1,%2]").arg(x).arg(y)
+                                         +	QString("</i><br/>at position [%1,%2]:<br/>").arg(x).arg(y)
                                          +	features_in_reach);
              
         }
@@ -542,7 +542,7 @@ void WeightedPointFeatureList2DViewController::hoverMoveEvent(QGraphicsSceneHove
             }
             else
             {
-                features_in_reach =		QString("<table align='center' border='1'><tr> <td>Idx</td> <td>x</td> <td>y</td> <td>weight</td> <td>dist</td> </tr>")
+                features_in_reach =		QString("<table><tr> <th>Idx</th> <th>x</th> <th>y</th> <th>weight</th> <th>dist</th> </tr>")
                 +	features_in_reach
                 +	QString("</table>");
             }
@@ -550,7 +550,7 @@ void WeightedPointFeatureList2DViewController::hoverMoveEvent(QGraphicsSceneHove
             emit updateStatusText(features->shortName() + QString("[%1,%2]").arg(x).arg(y));
             emit updateStatusDescription(	QString("<b>Mouse moved over Object: </b><br/><i>") 
                                          +	features->shortName()
-                                         +	QString("</i><br/>at position [%1,%2]").arg(x).arg(y)
+                                         +	QString("</i><br/>at position [%1,%2]:<br/>").arg(x).arg(y)
                                          +	features_in_reach);
              
         }
@@ -762,7 +762,7 @@ void EdgelFeatureList2DViewController::hoverMoveEvent(QGraphicsSceneHoverEvent *
             }
             else
             {
-                features_in_reach =		QString("<table align='center' border='1'><tr> <td>Idx</td> <td>x</td> <td>y</td> <td>weight</td> <td>angle</td> <td>dist</td> </tr>")
+                features_in_reach =		QString("<table><tr> <th>Idx</th> <th>x</th> <th>y</th> <th>weight</th> <th>angle</th> <th>dist</th> </tr>")
                 +	features_in_reach
                 +	QString("</table>");
             }
@@ -770,7 +770,7 @@ void EdgelFeatureList2DViewController::hoverMoveEvent(QGraphicsSceneHoverEvent *
             emit updateStatusText(features->shortName() + QString("[%1,%2]").arg(x).arg(y));
             emit updateStatusDescription(	QString("<b>Mouse moved over Object: </b><br/><i>") 
                                          +	features->shortName()
-                                         +	QString("</i><br/>at position [%1,%2]").arg(x).arg(y)
+                                         +	QString("</i><br/>at position [%1,%2]:<br/>").arg(x).arg(y)
                                          +	features_in_reach);
         }
     }
@@ -1006,7 +1006,7 @@ void SIFTFeatureList2DViewController::hoverMoveEvent(QGraphicsSceneHoverEvent * 
             }
             else
             {
-                features_in_reach =		QString("<table align='center' border='1'><tr> <td>Idx</td> <td>x</td> <td>y</td> <td>weight</td> <td>angle</td>  <td>scale</td> <td>dist</td> </tr>")
+                features_in_reach =		QString("<table><tr> <th>Idx</th> <th>x</th> <th>y</th> <th>weight</th> <th>angle</th>  <th>scale</th> <th>dist</th> </tr>")
                 +	features_in_reach
                 +	QString("</table>");
             }
@@ -1014,7 +1014,7 @@ void SIFTFeatureList2DViewController::hoverMoveEvent(QGraphicsSceneHoverEvent * 
             emit updateStatusText(features->shortName() + QString("[%1,%2]").arg(x).arg(y));
             emit updateStatusDescription(	QString("<b>Mouse moved over Object: </b><br/><i>") 
                                          +	features->shortName()
-                                         +	QString("</i><br/>at position [%1,%2]").arg(x).arg(y)
+                                         +	QString("</i><br/>at position [%1,%2]:<br/>").arg(x).arg(y)
                                          +	features_in_reach);
         }
     }

--- a/src/modules/features2d/featurelistviewcontroller.cxx
+++ b/src/modules/features2d/featurelistviewcontroller.cxx
@@ -163,7 +163,7 @@ QRectF PointFeatureList2DViewController::boundingRect() const
  *
  * \return Always: "PointFeatureList2DViewController"
  */
-QString PointFeatureList2DViewController::typeName()
+QString PointFeatureList2DViewController::typeName() const
 {
     return "PointFeatureList2DViewController";
 }
@@ -445,7 +445,7 @@ QRectF WeightedPointFeatureList2DViewController::boundingRect() const
  *
  * \return Always: "WeightedPointFeatureList2DViewController"
  */
-QString WeightedPointFeatureList2DViewController::typeName()
+QString WeightedPointFeatureList2DViewController::typeName() const
 {
 	return "WeightedPointFeatureList2DViewController";
 }
@@ -714,7 +714,7 @@ void EdgelFeatureList2DViewController::paint(QPainter *painter, const QStyleOpti
  *
  * \return Always: "EdgelList2DViewController"
  */
-QString EdgelFeatureList2DViewController::typeName()
+QString EdgelFeatureList2DViewController::typeName() const
 {
 	return "EdgelFeatureList2DViewController";
 }
@@ -958,7 +958,7 @@ void SIFTFeatureList2DViewController::paint(QPainter *painter, const QStyleOptio
  *
  * \return Always: "SIFTFeatureList2DViewController"
  */
-QString SIFTFeatureList2DViewController::typeName()
+QString SIFTFeatureList2DViewController::typeName() const
 {
 	return "SIFTFeatureList2DViewController"; 
 }

--- a/src/modules/features2d/featurelistviewcontroller.cxx
+++ b/src/modules/features2d/featurelistviewcontroller.cxx
@@ -163,7 +163,7 @@ QRectF PointFeatureList2DViewController::boundingRect() const
  *
  * \return Always: "PointFeatureList2DViewController"
  */
-QString PointFeatureList2DViewController::typeName() const
+QString PointFeatureList2DViewController::typeName()
 {
     return "PointFeatureList2DViewController";
 }
@@ -445,7 +445,7 @@ QRectF WeightedPointFeatureList2DViewController::boundingRect() const
  *
  * \return Always: "WeightedPointFeatureList2DViewController"
  */
-QString WeightedPointFeatureList2DViewController::typeName() const
+QString WeightedPointFeatureList2DViewController::typeName()
 {
 	return "WeightedPointFeatureList2DViewController";
 }
@@ -714,7 +714,7 @@ void EdgelFeatureList2DViewController::paint(QPainter *painter, const QStyleOpti
  *
  * \return Always: "EdgelList2DViewController"
  */
-QString EdgelFeatureList2DViewController::typeName() const
+QString EdgelFeatureList2DViewController::typeName()
 {
 	return "EdgelFeatureList2DViewController";
 }
@@ -958,7 +958,7 @@ void SIFTFeatureList2DViewController::paint(QPainter *painter, const QStyleOptio
  *
  * \return Always: "SIFTFeatureList2DViewController"
  */
-QString SIFTFeatureList2DViewController::typeName() const
+QString SIFTFeatureList2DViewController::typeName()
 {
 	return "SIFTFeatureList2DViewController"; 
 }

--- a/src/modules/features2d/featurelistviewcontroller.hxx
+++ b/src/modules/features2d/featurelistviewcontroller.hxx
@@ -91,7 +91,7 @@ class GRAIPE_FEATURES2D_EXPORT PointFeatureList2DViewController
          *
          * \return Always: "PointFeatureList2DViewController"
          */
-        static QString typeName();
+        virtual QString typeName() const;
         
     protected:
         /**
@@ -165,7 +165,7 @@ class GRAIPE_FEATURES2D_EXPORT WeightedPointFeatureList2DViewController
          *
          * \return Always: "WeightedPointFeatureList2DViewController"
          */
-		static QString typeName();
+		virtual QString typeName() const;
     
         /**
          * Specialization of the update of  the parameters of this ViewController according to the current
@@ -255,7 +255,7 @@ class GRAIPE_FEATURES2D_EXPORT EdgelFeatureList2DViewController
          *
          * \return Always: "EdgelList2DViewController"
          */
-		static QString typeName();
+		virtual QString typeName() const;
 
 	protected:
         /**
@@ -315,7 +315,7 @@ class GRAIPE_FEATURES2D_EXPORT SIFTFeatureList2DViewController
          *
          * \return Always: "SIFTFeatureList2DViewController"
          */
-		static QString typeName();
+		virtual QString typeName() const;
     
 	protected:
         /**

--- a/src/modules/features2d/featurelistviewcontroller.hxx
+++ b/src/modules/features2d/featurelistviewcontroller.hxx
@@ -91,7 +91,7 @@ class GRAIPE_FEATURES2D_EXPORT PointFeatureList2DViewController
          *
          * \return Always: "PointFeatureList2DViewController"
          */
-        QString typeName() const;
+        static QString typeName();
         
     protected:
         /**
@@ -165,7 +165,7 @@ class GRAIPE_FEATURES2D_EXPORT WeightedPointFeatureList2DViewController
          *
          * \return Always: "WeightedPointFeatureList2DViewController"
          */
-		QString typeName() const;
+		static QString typeName();
     
         /**
          * Specialization of the update of  the parameters of this ViewController according to the current
@@ -255,7 +255,7 @@ class GRAIPE_FEATURES2D_EXPORT EdgelFeatureList2DViewController
          *
          * \return Always: "EdgelList2DViewController"
          */
-		QString typeName() const;
+		static QString typeName();
 
 	protected:
         /**
@@ -315,7 +315,7 @@ class GRAIPE_FEATURES2D_EXPORT SIFTFeatureList2DViewController
          *
          * \return Always: "SIFTFeatureList2DViewController"
          */
-		QString typeName() const;
+		static QString typeName();
     
 	protected:
         /**

--- a/src/modules/features2d/polygon.cxx
+++ b/src/modules/features2d/polygon.cxx
@@ -49,7 +49,7 @@ Polygon2D::~Polygon2D()
  *
  * \return Always: "Polygon2D"
  */
-QString Polygon2D::typeName()
+QString Polygon2D::typeName() const
 {
 	return "Polygon2D";
 }

--- a/src/modules/features2d/polygon.cxx
+++ b/src/modules/features2d/polygon.cxx
@@ -49,7 +49,7 @@ Polygon2D::~Polygon2D()
  *
  * \return Always: "Polygon2D"
  */
-QString Polygon2D::typeName() const
+QString Polygon2D::typeName()
 {
 	return "Polygon2D";
 }

--- a/src/modules/features2d/polygon.hxx
+++ b/src/modules/features2d/polygon.hxx
@@ -62,7 +62,7 @@ class GRAIPE_FEATURES2D_EXPORT Polygon2D
          *
          * \return Always: "Polygon2D"
          */
-        QString typeName() const;
+        static QString typeName();
 		
         /**
          * Check if the polygon is closed.

--- a/src/modules/features2d/polygon.hxx
+++ b/src/modules/features2d/polygon.hxx
@@ -62,7 +62,7 @@ class GRAIPE_FEATURES2D_EXPORT Polygon2D
          *
          * \return Always: "Polygon2D"
          */
-        static QString typeName();
+        virtual QString typeName() const;
 		
         /**
          * Check if the polygon is closed.

--- a/src/modules/features2d/polygonlist.cxx
+++ b/src/modules/features2d/polygonlist.cxx
@@ -201,11 +201,11 @@ bool PolygonList2D::deserialize_item(const QString & serial)
 }
 
 /**
- * Serialization the list of polygons to a QIODevice.
+ * Serialization the list of polygons to an xml file.
  * The first line is the header as given in item_header(). Each following
  * line represents one polygon serialization.
  *
- * \param out The QIODevice, where we will put our output on.
+ * \param xmlWriter The QXmlStreamWriter where we will put our output on.
  */
 void PolygonList2D::serialize_content(QXmlStreamWriter& xmlWriter) const
 {
@@ -221,11 +221,11 @@ void PolygonList2D::serialize_content(QXmlStreamWriter& xmlWriter) const
 }
 
 /**
- * Deserializion of a list of polygons from a QIODevice.
+ * Deserialization of a list of polygons from an xml file.
  * The first line is the header as given in item_header(), which is ignored however.
  * Each following line has to be one valid polygon serialization.
  *
- * \param in The QIODevice, where we will read from.
+ * \param xmlReader The QXmlStreamReader, where we will read from.
  */
 bool PolygonList2D::deserialize_content(QXmlStreamReader& xmlReader)
 {

--- a/src/modules/features2d/polygonlist.cxx
+++ b/src/modules/features2d/polygonlist.cxx
@@ -209,14 +209,15 @@ bool PolygonList2D::deserialize_item(const QString & serial)
  */
 void PolygonList2D::serialize_content(QXmlStreamWriter& xmlWriter) const
 {
-//TODO!!!
-/*	write_on_device(item_header(), out);
-	
-    for(unsigned int index=0; index < size()-1; ++index)
+    xmlWriter.writeTextElement("Legend", item_header());
+    
+	for(unsigned int i=0; i < size(); ++i)
     {
-		write_on_device("\n" + serialize_item(index), out);
-	}
-    */
+        xmlWriter.writeStartElement("Polygon");
+        xmlWriter.writeAttribute("ID", QString::number(i));
+            xmlWriter.writeCharacters(serialize_item(i));
+        xmlWriter.writeEndElement();
+    }
 }
 
 /**
@@ -228,36 +229,27 @@ void PolygonList2D::serialize_content(QXmlStreamWriter& xmlWriter) const
  */
 bool PolygonList2D::deserialize_content(QXmlStreamReader& xmlReader)
 {
-//TODO!!!
-/**    if(locked())
+    if (locked())
         return false;
-        
-    //Read in header line and then throw it away immideately
-    if(!in.atEnd())
-        in.readLine();
-    
+
     //Clean up
 	clear();
     updateModel();
     
     //Read the entries
-    while(!in.atEnd())
+    while(xmlReader.readNextStartElement())
     {
-        QString line = QString(in.readLine());
-        
-        //ignore comments and empty lines
-        if(!line.isEmpty() && !line.startsWith(";"))
+        if(xmlReader.name() == "Polygon")
         {
-            if (!deserialize_item(line))
-            {
-                qCritical() << "PolygonList2D::deserialize_content: Polygon could not be deserialized from: '" << line << "'";
+            if(!deserialize_item(xmlReader.readElementText()))
                 return false;
-            }
+        }
+        else
+        {
+            xmlReader.skipCurrentElement();
         }
     }
     return true;
-    */
-    return false;
 }
 
 

--- a/src/modules/features2d/polygonlist.cxx
+++ b/src/modules/features2d/polygonlist.cxx
@@ -63,7 +63,7 @@ PolygonList2D::PolygonList2D(const PolygonList2D& poly_list)
  *
  * \return Always "PolygonList2D".
  */
-QString PolygonList2D::typeName()
+QString PolygonList2D::typeName() const
 {
 	return "PolygonList2D";
 }
@@ -282,7 +282,7 @@ WeightedPolygonList2D::WeightedPolygonList2D(const WeightedPolygonList2D& poly_l
  *
  * \return Always "WeightedPolygonList2D".
  */
-QString WeightedPolygonList2D::typeName()
+QString WeightedPolygonList2D::typeName() const
 {
 	return "WeightedPolygonList2D";
 }

--- a/src/modules/features2d/polygonlist.cxx
+++ b/src/modules/features2d/polygonlist.cxx
@@ -226,9 +226,10 @@ void PolygonList2D::serialize_content(QXmlStreamWriter& xmlWriter) const
  *
  * \param in The QIODevice, where we will read from.
  */
-bool PolygonList2D::deserialize_content(QIODevice& in)
+bool PolygonList2D::deserialize_content(QXmlStreamReader& xmlReader)
 {
-    if(locked())
+//TODO!!!
+/**    if(locked())
         return false;
         
     //Read in header line and then throw it away immideately
@@ -255,6 +256,8 @@ bool PolygonList2D::deserialize_content(QIODevice& in)
         }
     }
     return true;
+    */
+    return false;
 }
 
 

--- a/src/modules/features2d/polygonlist.cxx
+++ b/src/modules/features2d/polygonlist.cxx
@@ -63,7 +63,7 @@ PolygonList2D::PolygonList2D(const PolygonList2D& poly_list)
  *
  * \return Always "PolygonList2D".
  */
-QString PolygonList2D::typeName() const
+QString PolygonList2D::typeName()
 {
 	return "PolygonList2D";
 }
@@ -137,7 +137,7 @@ void PolygonList2D::addPolygon(const PolygonType& poly)
  *
  * \return Always "p0_x, p0_y, p1_x, p1_y, ... , pN_x, pN_y".
  */
-QString PolygonList2D::item_header() const
+QString PolygonList2D::csvHeader() const
 {
 	return "p0_x, p0_y, p1_x, p1_y, ... , pN_x, pN_y";
 }
@@ -202,14 +202,14 @@ bool PolygonList2D::deserialize_item(const QString & serial)
 
 /**
  * Serialization the list of polygons to an xml file.
- * The first line is the header as given in item_header(). Each following
+ * The first line is the header as given in csvHeader. Each following
  * line represents one polygon serialization.
  *
  * \param xmlWriter The QXmlStreamWriter where we will put our output on.
  */
 void PolygonList2D::serialize_content(QXmlStreamWriter& xmlWriter) const
 {
-    xmlWriter.writeTextElement("Legend", item_header());
+    xmlWriter.writeTextElement("Legend", csvHeader());
     
 	for(unsigned int i=0; i < size(); ++i)
     {
@@ -222,7 +222,7 @@ void PolygonList2D::serialize_content(QXmlStreamWriter& xmlWriter) const
 
 /**
  * Deserialization of a list of polygons from an xml file.
- * The first line is the header as given in item_header(), which is ignored however.
+ * The first line is the header as given in csvHeader, which is ignored however.
  * Each following line has to be one valid polygon serialization.
  *
  * \param xmlReader The QXmlStreamReader, where we will read from.
@@ -282,7 +282,7 @@ WeightedPolygonList2D::WeightedPolygonList2D(const WeightedPolygonList2D& poly_l
  *
  * \return Always "WeightedPolygonList2D".
  */
-QString WeightedPolygonList2D::typeName() const
+QString WeightedPolygonList2D::typeName()
 {
 	return "WeightedPolygonList2D";
 }
@@ -374,9 +374,9 @@ void WeightedPolygonList2D::addPolygon(const PolygonType& poly, float w)
  *
  * \return Always "weight, p0_x, p0_y, p1_x, p1_y, ... , pN_x, pN_y".
  */
-QString WeightedPolygonList2D::item_header() const
+QString WeightedPolygonList2D::csvHeader() const
 {
-	return "weight, " + PolygonList2D::item_header();
+	return "weight, " + PolygonList2D::csvHeader();
 }
 
 /**

--- a/src/modules/features2d/polygonlist.cxx
+++ b/src/modules/features2d/polygonlist.cxx
@@ -207,14 +207,16 @@ bool PolygonList2D::deserialize_item(const QString & serial)
  *
  * \param out The QIODevice, where we will put our output on.
  */
-void PolygonList2D::serialize_content(QIODevice& out) const
+void PolygonList2D::serialize_content(QXmlStreamWriter& xmlWriter) const
 {
-	write_on_device(item_header(), out);
+//TODO!!!
+/*	write_on_device(item_header(), out);
 	
     for(unsigned int index=0; index < size()-1; ++index)
     {
 		write_on_device("\n" + serialize_item(index), out);
 	}
+    */
 }
 
 /**

--- a/src/modules/features2d/polygonlist.hxx
+++ b/src/modules/features2d/polygonlist.hxx
@@ -72,7 +72,7 @@ class GRAIPE_FEATURES2D_EXPORT PolygonList2D
          *
          * \return Always "PolygonList2D".
          */
-		static QString typeName();
+		virtual QString typeName() const;
     
         /**
          * Returns the number of polygons in this list.
@@ -188,7 +188,7 @@ class GRAIPE_FEATURES2D_EXPORT WeightedPolygonList2D
          *
          * \return Always "WeightedPolygonList2D".
          */
-        static QString typeName();
+        virtual QString typeName() const;
     
         /**
          * Getter of the weight of a polygon at a given index. May throw an error,

--- a/src/modules/features2d/polygonlist.hxx
+++ b/src/modules/features2d/polygonlist.hxx
@@ -143,7 +143,7 @@ class GRAIPE_FEATURES2D_EXPORT PolygonList2D
          *
          * \param out The QIODevice, where we will put our output on.
          */
-		void serialize_content(QIODevice& out) const;
+		void serialize_content(QXmlStreamWriter& xmlWriter) const;
     
         /**
          * Deserializion of a list of polygons from a QIODevice.

--- a/src/modules/features2d/polygonlist.hxx
+++ b/src/modules/features2d/polygonlist.hxx
@@ -152,7 +152,7 @@ class GRAIPE_FEATURES2D_EXPORT PolygonList2D
          *
          * \param in The QIODevice, where we will read from.
          */
-		bool deserialize_content(QIODevice& in);
+		bool deserialize_content(QXmlStreamReader& xmlReader);
     
     protected:
         //The polygons

--- a/src/modules/features2d/polygonlist.hxx
+++ b/src/modules/features2d/polygonlist.hxx
@@ -137,20 +137,20 @@ class GRAIPE_FEATURES2D_EXPORT PolygonList2D
         virtual bool deserialize_item(const QString & serial);
     
         /**
-         * Serialization the list of polygons to a QIODevice.
+         * Serialization the list of polygons to an xml file.
          * The first line is the header as given in item_header(). Each following
          * line represents one polygon serialization.
          *
-         * \param out The QIODevice, where we will put our output on.
+         * \param xmlWriter The QXmlStreamWriter where we will put our output on.
          */
 		void serialize_content(QXmlStreamWriter& xmlWriter) const;
     
         /**
-         * Deserializion of a list of polygons from a QIODevice.
+         * Deserialization of a list of polygons from an xml file.
          * The first line is the header as given in item_header(), which is ignored however.
          * Each following line has to be one valid polygon serialization.
          *
-         * \param in The QIODevice, where we will read from.
+         * \param xmlReader The QXmlStreamReader, where we will read from.
          */
 		bool deserialize_content(QXmlStreamReader& xmlReader);
     

--- a/src/modules/features2d/polygonlist.hxx
+++ b/src/modules/features2d/polygonlist.hxx
@@ -72,7 +72,7 @@ class GRAIPE_FEATURES2D_EXPORT PolygonList2D
          *
          * \return Always "PolygonList2D".
          */
-		QString typeName() const;
+		static QString typeName();
     
         /**
          * Returns the number of polygons in this list.
@@ -116,7 +116,7 @@ class GRAIPE_FEATURES2D_EXPORT PolygonList2D
          *
          * \return Always "p0_x, p0_y, p1_x, p1_y, ... , pN_x, pN_y".
          */
-		virtual QString item_header() const;
+		virtual QString csvHeader() const;
     
         /**
          * Serialization of one polygon at a given list index to a string. This function will
@@ -138,7 +138,7 @@ class GRAIPE_FEATURES2D_EXPORT PolygonList2D
     
         /**
          * Serialization the list of polygons to an xml file.
-         * The first line is the header as given in item_header(). Each following
+         * The first line is the header as given in csvHeader. Each following
          * line represents one polygon serialization.
          *
          * \param xmlWriter The QXmlStreamWriter where we will put our output on.
@@ -147,7 +147,7 @@ class GRAIPE_FEATURES2D_EXPORT PolygonList2D
     
         /**
          * Deserialization of a list of polygons from an xml file.
-         * The first line is the header as given in item_header(), which is ignored however.
+         * The first line is the header as given in csvHeader, which is ignored however.
          * Each following line has to be one valid polygon serialization.
          *
          * \param xmlReader The QXmlStreamReader, where we will read from.
@@ -188,7 +188,7 @@ class GRAIPE_FEATURES2D_EXPORT WeightedPolygonList2D
          *
          * \return Always "WeightedPolygonList2D".
          */
-        QString typeName() const;
+        static QString typeName();
     
         /**
          * Getter of the weight of a polygon at a given index. May throw an error,
@@ -251,7 +251,7 @@ class GRAIPE_FEATURES2D_EXPORT WeightedPolygonList2D
          *
          * \return Always "weight, p0_x, p0_y, p1_x, p1_y, ... , pN_x, pN_y".
          */
-		virtual QString item_header() const;
+		virtual QString csvHeader() const;
     
         /**
          * Serialization of one polygon at a given list index to a string. This function will

--- a/src/modules/features2d/polygonlist.hxx
+++ b/src/modules/features2d/polygonlist.hxx
@@ -125,7 +125,7 @@ class GRAIPE_FEATURES2D_EXPORT PolygonList2D
          * \param index The index of the polygon to be serialized.
          * \return A QString containing the searialization of the polygon.
          */
-        virtual QString serialize_item(unsigned int index) const;
+        virtual QString itemToCSV(unsigned int index) const;
     
         /**
          * Deserialization/addition of a polygon from a string to this list.
@@ -134,7 +134,25 @@ class GRAIPE_FEATURES2D_EXPORT PolygonList2D
          * \return True, if the item could be deserialized and the model is not locked.
          *         The serialization should be given as: p0_x, p0_y, ... , pN_x, pN_y
          */
-        virtual bool deserialize_item(const QString & serial);
+        virtual bool itemFromCSV(const QString & serial);
+    
+        /**
+         * Serialization of one polygon at a given list index to a string. This function will
+         * throw an error if the index is out of range.
+         *
+         * \param index The index of the polygon to be serialized.
+         * \return A QString containing the searialization of the polygon.
+         */
+        virtual void serialize_item(unsigned int index, QXmlStreamWriter& xmlWriter) const;
+    
+        /**
+         * Deserialization/addition of a polygon from a string to this list.
+         *
+         * \param serial A QString containing the searialization of the polygon.
+         * \return True, if the item could be deserialized and the model is not locked.
+         *         The serialization should be given as: p0_x, p0_y, ... , pN_x, pN_y
+         */
+        virtual bool deserialize_item(QXmlStreamReader& xmlReader);
     
         /**
          * Serialization the list of polygons to an xml file.
@@ -260,7 +278,7 @@ class GRAIPE_FEATURES2D_EXPORT WeightedPolygonList2D
          * \param index The index of the polygon to be serialized.
          * \return A QString containing the searialization of the polygon.
          */
-        virtual QString serialize_item(unsigned int index) const;
+        virtual QString itemToCSV(unsigned int index) const;
     
         /**
          * Deserialization/addition of a polygon from a string to this list.
@@ -269,7 +287,25 @@ class GRAIPE_FEATURES2D_EXPORT WeightedPolygonList2D
          * \return True, if the item could be deserialized and the model is not locked.
          *         The serialization should be given as: p0_x, p0_y, ... , pN_x, pN_y
          */
-        virtual bool deserialize_item(const QString & serial);
+        virtual bool itemFromCSV(const QString & serial);
+    
+        /**
+         * Serialization of one polygon at a given list index to a string. This function will
+         * throw an error if the index is out of range.
+         *
+         * \param index The index of the polygon to be serialized.
+         * \return A QString containing the searialization of the polygon.
+         */
+        virtual void serialize_item(unsigned int index, QXmlStreamWriter& xmlWriter) const;
+    
+        /**
+         * Deserialization/addition of a polygon from a string to this list.
+         *
+         * \param serial A QString containing the searialization of the polygon.
+         * \return True, if the item could be deserialized and the model is not locked.
+         *         The serialization should be given as: p0_x, p0_y, ... , pN_x, pN_y
+         */
+        virtual bool deserialize_item(QXmlStreamReader& xmlReader);
     
     protected:
         //The weights

--- a/src/modules/features2d/polygonlistviewcontroller.cxx
+++ b/src/modules/features2d/polygonlistviewcontroller.cxx
@@ -123,7 +123,7 @@ QRectF PolygonList2DViewController::boundingRect() const
  *
  * \return Always: "PolygonList2DViewController"
  */
-QString PolygonList2DViewController::typeName() const
+QString PolygonList2DViewController::typeName()
 {
 	return "PolygonList2DViewController";
 }
@@ -333,7 +333,7 @@ QRectF WeightedPolygonList2DViewController::boundingRect() const
  *
  * \return Always: "WeightedPolygonList2DViewController"
  */
-QString WeightedPolygonList2DViewController::typeName() const
+QString WeightedPolygonList2DViewController::typeName()
 {
 	return "WeightedPolygonList2DViewController";
 }

--- a/src/modules/features2d/polygonlistviewcontroller.cxx
+++ b/src/modules/features2d/polygonlistviewcontroller.cxx
@@ -123,7 +123,7 @@ QRectF PolygonList2DViewController::boundingRect() const
  *
  * \return Always: "PolygonList2DViewController"
  */
-QString PolygonList2DViewController::typeName()
+QString PolygonList2DViewController::typeName() const
 {
 	return "PolygonList2DViewController";
 }
@@ -333,7 +333,7 @@ QRectF WeightedPolygonList2DViewController::boundingRect() const
  *
  * \return Always: "WeightedPolygonList2DViewController"
  */
-QString WeightedPolygonList2DViewController::typeName()
+QString WeightedPolygonList2DViewController::typeName() const
 {
 	return "WeightedPolygonList2DViewController";
 }

--- a/src/modules/features2d/polygonlistviewcontroller.hxx
+++ b/src/modules/features2d/polygonlistviewcontroller.hxx
@@ -92,7 +92,7 @@ class GRAIPE_FEATURES2D_EXPORT PolygonList2DViewController
          *
          * \return Always: "PolygonList2DViewController"
          */
-        QString typeName() const;
+        static QString typeName();
         
     protected:
         /**
@@ -164,7 +164,7 @@ class GRAIPE_FEATURES2D_EXPORT WeightedPolygonList2DViewController
          *
          * \return Always: "WeightedPolygonList2DViewController"
          */
-        QString typeName() const;
+        static QString typeName();
     
         /**
          * Specialization of the update of  the parameters of this ViewController according to the current

--- a/src/modules/features2d/polygonlistviewcontroller.hxx
+++ b/src/modules/features2d/polygonlistviewcontroller.hxx
@@ -92,7 +92,7 @@ class GRAIPE_FEATURES2D_EXPORT PolygonList2DViewController
          *
          * \return Always: "PolygonList2DViewController"
          */
-        static QString typeName();
+        virtual QString typeName() const;
         
     protected:
         /**
@@ -164,7 +164,7 @@ class GRAIPE_FEATURES2D_EXPORT WeightedPolygonList2DViewController
          *
          * \return Always: "WeightedPolygonList2DViewController"
          */
-        static QString typeName();
+        virtual QString typeName() const;
     
         /**
          * Specialization of the update of  the parameters of this ViewController according to the current

--- a/src/modules/imagefilter/imagefiltermodule.cxx
+++ b/src/modules/imagefilter/imagefiltermodule.cxx
@@ -112,7 +112,7 @@ class FrostFilter
          */
         FrostFilter()
         {
-            m_parameters->addParameter("image", new ModelParameter("Image",	NULL,  "Image"));
+            m_parameters->addParameter("image", new ModelParameter("Image",	"Image"));
             m_parameters->addParameter("size", new IntParameter("Filter window size", 1, 9999, 11));
             m_parameters->addParameter("k", new FloatParameter("Damping factor k", 0, 1, 1));
             m_parameters->addParameter("bt", new EnumParameter("Border treatment", m_border_treatment_modes, 2));
@@ -216,7 +216,7 @@ class EnhancedFrostFilter
          */
         EnhancedFrostFilter()
         {
-            m_parameters->addParameter("image", new ModelParameter("Image",	NULL,  "Image"));
+            m_parameters->addParameter("image", new ModelParameter("Image",	"Image"));
             m_parameters->addParameter("size", new IntParameter("Filter window size", 1, 9999, 11));
             m_parameters->addParameter("k", new FloatParameter("Damping factor k", 0, 1, 1));
             m_parameters->addParameter("ENL", new IntParameter("Equivalent Number of looks (ENL)", 1, 100, 4));
@@ -324,7 +324,7 @@ class GammaMAPFilter
          */
         GammaMAPFilter()
         {
-            m_parameters->addParameter("image", new ModelParameter("Image",	NULL,  "Image"));
+            m_parameters->addParameter("image", new ModelParameter("Image",	"Image"));
             m_parameters->addParameter("size", new IntParameter("Filter window size", 1, 9999, 11));
             m_parameters->addParameter("ENL", new IntParameter("Equivalent Number of looks (ENL)", 1, 100, 4));
             m_parameters->addParameter("bt", new EnumParameter("Border treatment", m_border_treatment_modes, 2));
@@ -428,7 +428,7 @@ class KuanFilter
          */
         KuanFilter()
         {
-            m_parameters->addParameter("image", new ModelParameter("Image",	NULL,  "Image"));
+            m_parameters->addParameter("image", new ModelParameter("Image",	"Image"));
             m_parameters->addParameter("size", new IntParameter("Filter window size", 1, 9999, 11));
             m_parameters->addParameter("ENL", new IntParameter("Equivalent Number of looks (ENL)", 1, 100, 4));
             m_parameters->addParameter("bt", new EnumParameter("Border treatment", m_border_treatment_modes, 2));
@@ -532,7 +532,7 @@ class LeeFilter
          */
         LeeFilter()
         {
-            m_parameters->addParameter("image", new ModelParameter("Image",	NULL,  "Image"));
+            m_parameters->addParameter("image", new ModelParameter("Image",	"Image"));
             m_parameters->addParameter("size", new IntParameter("Filter window size", 1, 9999, 11));
             m_parameters->addParameter("ENL", new IntParameter("Equivalent Number of looks (ENL)", 1, 100, 4));
             m_parameters->addParameter("bt", new EnumParameter("Border treatment", m_border_treatment_modes, 2));
@@ -639,7 +639,7 @@ class EnhancedLeeFilter
          */
         EnhancedLeeFilter()
         {
-            m_parameters->addParameter("image", new ModelParameter("Image",	NULL,  "Image"));
+            m_parameters->addParameter("image", new ModelParameter("Image",	"Image"));
             m_parameters->addParameter("size", new IntParameter("Filter window size", 1, 9999, 11));
             m_parameters->addParameter("k", new FloatParameter("Damping factor k", 0, 1, 1));
             m_parameters->addParameter("ENL", new IntParameter("Equivalent Number of looks (ENL)", 1, 100, 4));
@@ -745,7 +745,7 @@ class MedianFilter
          */
         MedianFilter()
         {
-            m_parameters->addParameter("image", new ModelParameter("Image",	NULL,  "Image"));
+            m_parameters->addParameter("image", new ModelParameter("Image",	"Image"));
             m_parameters->addParameter("size", new IntParameter("Filter window size", 1, 9999, 11));
             m_parameters->addParameter("bt", new EnumParameter("Border treatment", m_border_treatment_modes, 2));
             m_results.push_back(new Image<float>);
@@ -846,7 +846,7 @@ class ShockFilter
          */    
         ShockFilter()
         {
-            m_parameters->addParameter("image", new ModelParameter("Image",	NULL,  "Image"));
+            m_parameters->addParameter("image", new ModelParameter("Image",	"Image"));
             m_parameters->addParameter("sigma1", new FloatParameter("inner Sigma", 0.0, 100, 0.7f));
             m_parameters->addParameter("sigma2", new FloatParameter("outer Sigma", 0.0, 100, 3));
             m_parameters->addParameter("upwind", new FloatParameter("upwinding factor", 0.0, 10.0, 0.3f));

--- a/src/modules/imageprocessing/imageprocessingmodule.cxx
+++ b/src/modules/imageprocessing/imageprocessingmodule.cxx
@@ -105,7 +105,7 @@ class AddImages
                         
                         //Copy all metadata from current image (will be overwritten later)
                         image->copyMetadata(*new_image);
-                        new_image->setName(QString("addition of ") + param_images->valueText());
+                        new_image->setName(QString("addition of ") + param_images->toString());
                         
                         //iterate
                         for(unsigned int i = 0; i < selected_images.size(); ++i)
@@ -690,7 +690,7 @@ class MaskErosion
                     //Copy all metadata from current image (will be overwritten later)
                     param_mask->image()->copyMetadata(*new_image);
                     
-                    new_image->setName(QString("Mask erosion: ") + param_mask->valueText());
+                    new_image->setName(QString("Mask erosion: ") + param_mask->toString());
                     
                     vigra::multiBinaryErosion(mask,
                                        new_image->band(0),
@@ -783,7 +783,7 @@ class MaskDilation
                     //Copy all metadata from current image (will be overwritten later)
                     param_mask->image()->copyMetadata(*new_image);
                     
-                    new_image->setName(QString("Mask dilation: ") + param_mask->valueText());
+                    new_image->setName(QString("Mask dilation: ") + param_mask->toString());
                     
                     vigra::multiBinaryDilation(mask,
                                         new_image->band(0),
@@ -968,7 +968,7 @@ class MaskIntersection: public Algorithm
                     //Copy all metadata from current image (will be overwritten later)
                     param_mask1->image()->copyMetadata(*new_image);
                     
-                    new_image->setName(QString("Mask intersec.: ") + param_mask1->valueText() + " and " + param_mask2->valueText());
+                    new_image->setName(QString("Mask intersec.: ") + param_mask1->toString() + " and " + param_mask2->toString());
                     
                     using namespace vigra::functor;
                     
@@ -1062,7 +1062,7 @@ class MaskDifference: public Algorithm
                     //Copy all metadata from current image (will be overwritten later)
                     param_mask1->image()->copyMetadata(*new_image);
                     
-                    new_image->setName(QString("Mask difference: ") + param_mask1->valueText() + " and " + param_mask2->valueText());
+                    new_image->setName(QString("Mask difference: ") + param_mask1->toString() + " and " + param_mask2->toString());
                     
                     using namespace vigra::functor;
                     
@@ -1518,7 +1518,7 @@ class ImageThresholder
                     //Copy all metadata from current image (will be overwritten later)
                     param_imageBand->image()->copyMetadata(*new_image);
                     
-                    new_image->setName(QString("thresholded ") + param_imageBand->valueText());
+                    new_image->setName(QString("thresholded ") + param_imageBand->toString());
                     
                     using namespace vigra::functor;
                     
@@ -1660,7 +1660,7 @@ class FloatingImageThresholder
                     //Copy all metadata from current image (will be overwritten later)
                     param_imageBand->image()->copyMetadata(*new_image);
                     
-                    new_image->setName(QString("floating thresholded ") + param_imageBand->valueText());
+                    new_image->setName(QString("floating thresholded ") + param_imageBand->toString());
                     
                     
                     QString descr("The following parameters were used for floating thresholding:\n");
@@ -1828,8 +1828,8 @@ class ThinLineExtractor
                     param_imageBand->image()->copyMetadata(*new_image);
                     param_imageBand->image()->copyMetadata(*new_stat_image);
                     
-                    new_image->setName(QString("filtered ") + param_imageBand->valueText());
-                    new_stat_image->setName(QString("region stats. of filtered ") + param_imageBand->valueText());
+                    new_image->setName(QString("filtered ") + param_imageBand->toString());
+                    new_stat_image->setName(QString("region stats. of filtered ") + param_imageBand->toString());
                     
                     
                     QString descr("The following parameters were used for finding thin lines:\n");
@@ -1925,7 +1925,7 @@ class DistanceTransformator
                     //Copy all metadata from current image (will be overwritten later)
                     param_imageBand->image()->copyMetadata(*new_image);
                     
-                    new_image->setName(QString("distance transform of ") + param_imageBand->valueText());
+                    new_image->setName(QString("distance transform of ") + param_imageBand->toString());
                     
                     using namespace vigra::functor;
                     vigra::distanceTransform(imageband, new_image->band(0), 1 ,2);

--- a/src/modules/imageprocessing/imageprocessingmodule.cxx
+++ b/src/modules/imageprocessing/imageprocessingmodule.cxx
@@ -61,7 +61,7 @@ class AddImages
          */
         AddImages()
         {
-            m_parameters->addParameter("images", new MultiModelParameter("Images",	NULL,  "Image"));
+            m_parameters->addParameter("images", new MultiModelParameter("Images",	"Image"));
         }
     
         /**
@@ -255,7 +255,7 @@ class RecursiveSmoothingFilter : public Algorithm
          */
         RecursiveSmoothingFilter()
         {
-            m_parameters->addParameter("image", new ModelParameter("Image",	NULL,  "Image"));
+            m_parameters->addParameter("image", new ModelParameter("Image",	"Image"));
             m_parameters->addParameter("sigma", new FloatParameter("Scale sigma", 0.0, 50.0, 1.0));
             //m_parameters.push_back( new EnumParameter("Border treatment", border_treatment_modes(), 2));
             
@@ -350,7 +350,7 @@ class GaussianSmoothingFilter : public Algorithm
          */
         GaussianSmoothingFilter()
         {
-            m_parameters->addParameter("image", new ModelParameter("Image",	NULL,  "Image"));
+            m_parameters->addParameter("image", new ModelParameter("Image",	"Image"));
             m_parameters->addParameter("sigma", new FloatParameter("Scale sigma", 0.0, 50.0, 1.0));
         }
         
@@ -447,9 +447,9 @@ class NormalizedGaussianSmoothingFilter : public Algorithm
          */
         NormalizedGaussianSmoothingFilter()
         {
-            m_parameters->addParameter("image", new ModelParameter("Image",	NULL,  "Image"));
+            m_parameters->addParameter("image", new ModelParameter("Image",	"Image"));
             m_parameters->addParameter("sigma", new FloatParameter("Scale sigma", 0.0, 50.0, 1.0));
-            m_parameters->addParameter("mask",  new ImageBandParameter<float>("Mask image Band",NULL) );
+            m_parameters->addParameter("mask",  new ImageBandParameter<float>("Mask image Band"));
         }
     
         /**
@@ -553,8 +553,8 @@ class ApplyMaskToImage
          */
         ApplyMaskToImage()
         {
-            m_parameters->addParameter("image", new ModelParameter("Image",	NULL,  "Image"));
-            m_parameters->addParameter("mask",  new ImageBandParameter<float>("Mask image Band",NULL) );
+            m_parameters->addParameter("image", new ModelParameter("Image",	"Image"));
+            m_parameters->addParameter("mask",  new ImageBandParameter<float>("Mask image Band"));
             
         }
     
@@ -1120,7 +1120,7 @@ class ImageCropper
          */
         ImageCropper()
         {
-            m_parameters->addParameter("image", new ModelParameter("Image",	NULL,  "Image"));
+            m_parameters->addParameter("image", new ModelParameter("Image", "Image"));
             m_parameters->addParameter("ul_x", new IntParameter("Upper Left x", 0,999999, 0));
             m_parameters->addParameter("ul_y", new IntParameter("Upper Left y", 0,999999, 0));
             m_parameters->addParameter("lr_x", new IntParameter("Lower Right x", 0,999999, 1000));
@@ -1241,7 +1241,7 @@ class ImageResizer : public Algorithm
          */
         ImageResizer()
         {
-            m_parameters->addParameter("image",  new ModelParameter("Image",	NULL,  "Image"));
+            m_parameters->addParameter("image",  new ModelParameter("Image", "Image"));
             m_parameters->addParameter("width",  new IntParameter("New width", 1,999999, 100));
             m_parameters->addParameter("height", new IntParameter("New height ", 1,999999, 100));
             m_parameters->addParameter("degree", new IntParameter("Spline-Interpolation degree ", 0,5, 1));
@@ -1366,7 +1366,7 @@ class ImageInverter
          */
         ImageInverter()
         {
-            m_parameters->addParameter("image", new ModelParameter("Image",	NULL,  "Image"));
+            m_parameters->addParameter("image", new ModelParameter("Image", "Image"));
             m_parameters->addParameter("invert", new BoolParameter("Use maximum band value as inverting offset",true));
             m_parameters->addParameter("invert_offset", new IntParameter("Global inverting offset", 0,999999, 255, (*m_parameters)["invert"]));
             

--- a/src/modules/images/geocoding.hxx
+++ b/src/modules/images/geocoding.hxx
@@ -249,7 +249,7 @@ class GCP
             return hasId();
         }
 
-        QString typeName() const
+        static QString typeName()
         {
             return "GCP";
         }

--- a/src/modules/images/geocoding.hxx
+++ b/src/modules/images/geocoding.hxx
@@ -249,7 +249,7 @@ class GCP
             return hasId();
         }
 
-        static QString typeName()
+        virtual QString typeName() const
         {
             return "GCP";
         }

--- a/src/modules/images/image.cxx
+++ b/src/modules/images/image.cxx
@@ -103,7 +103,7 @@ template<class T>
 Image<T>::Image(Size_Type size, 
                 unsigned int numBands,
                 DateTime_Type timestamp,
-                String_Type filename,
+                String_Type id,
                 Comment_Type comment,
                 Units_Type units,
                 Scale_Type scale)
@@ -116,7 +116,7 @@ Image<T>::Image(Size_Type size,
     m_units(new StringParameter("Units:", units))
 {
     appendParameters();
-    setFilename(filename);
+    setID(id);
     setWidth((unsigned int)size[0]);
     setHeight((unsigned int)size[1]);
     setNumBands(numBands);

--- a/src/modules/images/image.cxx
+++ b/src/modules/images/image.cxx
@@ -36,8 +36,6 @@
 #include "images/image.hxx"
 #include "images/imageimpex.hxx"
 
-#include <QIODevice>
-
 namespace graipe {
 
 /**
@@ -417,10 +415,10 @@ void Image<T>::copyData(Model& other) const
 }
 
 /**
- * Serialization of the Image to a QIODevice.
+ * Serialization of the Image to an xml file.
  * The serialization is just a binary stream of all bands, one after the other.
  *
- * \param out The QIODevice, where we will put our output on.
+ * \param xmlWriter The QXmlStreamWriter where we will put our output on.
  */
 template<class T>
 void Image<T>::serialize_content(QXmlStreamWriter& xmlWriter) const
@@ -453,11 +451,11 @@ void Image<T>::serialize_content(QXmlStreamWriter& xmlWriter) const
 }
 
 /**
- * Deserializion of a list of polygons from a QIODevice.
+ * Deserialization of a list of polygons from an xml file.
  * Since the serialization is just a binary stream of all bands, one after the other
  * and we already know the size and count of bands, it is quite easy the deserialize.
  *
- * \param in The QIODevice, where we will read from.
+ * \param xmlReader The QXmlStreamReader, where we will read from.
  */
 template<class T>
 bool Image<T>::deserialize_content(QXmlStreamReader& xmlReader)

--- a/src/modules/images/image.cxx
+++ b/src/modules/images/image.cxx
@@ -138,7 +138,7 @@ Image<T>::~Image()
  * \return Always "Image".
  */
 template<>
-QString Image<float>::typeName()
+QString Image<float>::typeName() const
 {
     return "Image";
 }
@@ -150,7 +150,7 @@ QString Image<float>::typeName()
  * \return Always "IntImage".
  */
 template<>
-QString Image<int>::typeName()
+QString Image<int>::typeName() const
 {
     return "IntImage";
 }
@@ -162,7 +162,7 @@ QString Image<int>::typeName()
  * \return Always "ByteImage".
  */
 template<>
-QString Image<unsigned char>::typeName()
+QString Image<unsigned char>::typeName() const
 {
     return "ByteImage";
 }

--- a/src/modules/images/image.cxx
+++ b/src/modules/images/image.cxx
@@ -36,6 +36,8 @@
 #include "images/image.hxx"
 #include "images/imageimpex.hxx"
 
+#include <QIODevice>
+
 namespace graipe {
 
 /**
@@ -421,19 +423,19 @@ void Image<T>::copyData(Model& other) const
  * \param out The QIODevice, where we will put our output on.
  */
 template<class T>
-void Image<T>::serialize_content(QIODevice& out) const
+void Image<T>::serialize_content(QXmlStreamWriter& xmlWriter) const
 {
     qint64 channel_size = this->width()*this->height()*sizeof(T);
-    
+
     for(unsigned int c=0; c<m_imagebands.size(); ++c)
     {
+        QByteArray block((const char*)m_imagebands[c].data(),channel_size);
         
-        qint64 written_bytes = out.write((const char*)m_imagebands[c].data(),channel_size);
-        
-        if (written_bytes != channel_size)
-        {
-            qCritical() << "Image<T>::serialize_content: Error while writing band " << c << ". Expected to write " << channel_size << "bytes, but only wrote " << written_bytes << " bytes";
-        }
+        xmlWriter.writeStartElement("Channel");
+        xmlWriter.writeAttribute("ID", QString::number(c));
+        xmlWriter.writeAttribute("Encoding", "Base64");
+        xmlWriter.writeCharacters(block.toBase64());
+        xmlWriter.writeEndElement();
     }
 }
 

--- a/src/modules/images/image.cxx
+++ b/src/modules/images/image.cxx
@@ -447,9 +447,10 @@ void Image<T>::serialize_content(QXmlStreamWriter& xmlWriter) const
  * \param in The QIODevice, where we will read from.
  */
 template<class T>
-bool Image<T>::deserialize_content(QIODevice& in)
+bool Image<T>::deserialize_content(QXmlStreamReader& xmlReader)
 {
-    if(this->width() == 0 || this->height()==0 || this->numBands() ==0)
+ //TODO!!!
+/**   if(this->width() == 0 || this->height()==0 || this->numBands() ==0)
     {
         qCritical("Image<T>::deserialize_content: Image has zero size!");
         return false;
@@ -478,6 +479,8 @@ bool Image<T>::deserialize_content(QIODevice& in)
     }
         
     return true;
+    */
+    return false;
 }
 
 /**

--- a/src/modules/images/image.cxx
+++ b/src/modules/images/image.cxx
@@ -138,7 +138,7 @@ Image<T>::~Image()
  * \return Always "Image".
  */
 template<>
-QString Image<float>::typeName() const
+QString Image<float>::typeName()
 {
     return "Image";
 }
@@ -150,7 +150,7 @@ QString Image<float>::typeName() const
  * \return Always "IntImage".
  */
 template<>
-QString Image<int>::typeName() const
+QString Image<int>::typeName()
 {
     return "IntImage";
 }
@@ -162,7 +162,7 @@ QString Image<int>::typeName() const
  * \return Always "ByteImage".
  */
 template<>
-QString Image<unsigned char>::typeName() const
+QString Image<unsigned char>::typeName()
 {
     return "ByteImage";
 }

--- a/src/modules/images/image.hxx
+++ b/src/modules/images/image.hxx
@@ -111,7 +111,7 @@ class GRAIPE_IMAGES_EXPORT Image
          *
          * \return the typeName of the Image.
          */
-        QString typeName() const;
+        static QString typeName();
     
         /**
          * Check if an Image has  > 0 pixels

--- a/src/modules/images/image.hxx
+++ b/src/modules/images/image.hxx
@@ -257,7 +257,7 @@ class GRAIPE_IMAGES_EXPORT Image
          *
          * \param in The QIODevice, where we will read from.
          */
-		bool deserialize_content(QIODevice& in);
+		bool deserialize_content(QXmlStreamReader& xmlReader);
 	
     public slots:
         /**

--- a/src/modules/images/image.hxx
+++ b/src/modules/images/image.hxx
@@ -248,7 +248,7 @@ class GRAIPE_IMAGES_EXPORT Image
          *
          * \param out The QIODevice, where we will put our output on.
          */
-		void serialize_content(QIODevice& out) const;
+		void serialize_content(QXmlStreamWriter& xmlWriter) const;
     
         /**
          * Deserializion of a list of polygons from a QIODevice.

--- a/src/modules/images/image.hxx
+++ b/src/modules/images/image.hxx
@@ -111,7 +111,7 @@ class GRAIPE_IMAGES_EXPORT Image
          *
          * \return the typeName of the Image.
          */
-        static QString typeName();
+        virtual QString typeName() const;
     
         /**
          * Check if an Image has  > 0 pixels

--- a/src/modules/images/image.hxx
+++ b/src/modules/images/image.hxx
@@ -243,19 +243,19 @@ class GRAIPE_IMAGES_EXPORT Image
 		void copyData(Model& other) const;
 	
         /**
-         * Serialization of the Image to a QIODevice.
+         * Serialization of the Image to an xml file.
          * The serialization is just a binary stream of all bands, one after the other.
          *
-         * \param out The QIODevice, where we will put our output on.
+         * \param xmlWriter The QXmlStreamWriter where we will put our output on.
          */
 		void serialize_content(QXmlStreamWriter& xmlWriter) const;
     
         /**
-         * Deserializion of a list of polygons from a QIODevice.
+         * Deserialization of a list of polygons from an xml file.
          * Since the serialization is just a binary stream of all bands, one after the other
          * and we already know the size and count of bands, it is quite easy the deserialize.
          *
-         * \param in The QIODevice, where we will read from.
+         * \param xmlReader The QXmlStreamReader, where we will read from.
          */
 		bool deserialize_content(QXmlStreamReader& xmlReader);
 	

--- a/src/modules/images/imagebandparameter.cxx
+++ b/src/modules/images/imagebandparameter.cxx
@@ -313,7 +313,7 @@ void ImageBandParameter<T>::serialize(QXmlStreamWriter& xmlWriter) const
 {    
     xmlWriter.setAutoFormatting(true);
     
-    xmlWriter.writeStartElement(magicID());
+    xmlWriter.writeStartElement(typeName());
     xmlWriter.writeTextElement("Name", name());
     xmlWriter.writeTextElement("Filename", m_image->filename());
     xmlWriter.writeTextElement("BandID", QString::number(m_bandId));
@@ -335,7 +335,7 @@ bool ImageBandParameter<T>::deserialize(QXmlStreamReader& xmlReader)
     {
         if (xmlReader.readNextStartElement())
         {            
-            if(xmlReader.name() == magicID())
+            if(xmlReader.name() == typeName())
             {
                 for(int i=0; i!=3; ++i)
                 {
@@ -371,7 +371,7 @@ bool ImageBandParameter<T>::deserialize(QXmlStreamReader& xmlReader)
                         return false;
                     }
                     
-                    if(xmlReader.isEndElement() && xmlReader.name() == magicID())
+                    if(xmlReader.isEndElement() && xmlReader.name() == typeName())
                     {
                         break;
                     }
@@ -381,13 +381,13 @@ bool ImageBandParameter<T>::deserialize(QXmlStreamReader& xmlReader)
         }
         else
         {
-            throw std::runtime_error("Did not find magicID in XML tree");
+            throw std::runtime_error("Did not find typeName() in XML tree");
         }
         throw std::runtime_error("Did not find any start element in XML tree");
     }
     catch(std::runtime_error & e)
     {
-        qCritical() << magicID() << "::deserialize failed! Was looking for magicID: " << magicID() << "Error: " << e.what();
+        qCritical() << typeName() << "::deserialize failed! Was looking for typeName(): " << typeName() << "Error: " << e.what();
         return false;
     }
 }

--- a/src/modules/images/imagebandparameter.cxx
+++ b/src/modules/images/imagebandparameter.cxx
@@ -255,7 +255,7 @@ void ImageBandParameter<T>::setBandId(unsigned int bandid)
  * \return The value of the parameter converted to an QString.
  */
 template <class T>
-QString ImageBandParameter<T>::valueText() const
+QString ImageBandParameter<T>::toString() const
 {
 	if(!isValid())
 	{
@@ -303,7 +303,7 @@ void ImageBandParameter<T>::refresh()
 
 /**
  * Serialization of the parameter's state to a string. Please note, that this can 
- * vary from the valueText() result, which also returns a string. This is due to the fact,
+ * vary from the toString() result, which also returns a string. This is due to the fact,
  * that serialize also may perform encoding of strings to avoid special chars.
  *
  * \return The serialization of the parameter's state.
@@ -327,9 +327,10 @@ void ImageBandParameter<T>::serialize(QXmlStreamWriter& xmlWriter) const
  * \return True, if the deserialization was successful, else false.
  */
 template <class T>
-bool ImageBandParameter<T>::deserialize(QIODevice & in)
+bool ImageBandParameter<T>::deserialize(QXmlStreamReader& xmlReader)
 {
-
+//TODO!!!
+/**
     if (!Parameter::deserialize(in))
     {
         return false;
@@ -371,6 +372,7 @@ bool ImageBandParameter<T>::deserialize(QIODevice & in)
         
         return found;
     }
+    */
     return false;
 }
 

--- a/src/modules/images/imagebandparameter.cxx
+++ b/src/modules/images/imagebandparameter.cxx
@@ -316,7 +316,7 @@ void ImageBandParameter<T>::serialize(QXmlStreamWriter& xmlWriter) const
     
     xmlWriter.writeStartElement(typeName());
     xmlWriter.writeTextElement("Name", name());
-    xmlWriter.writeTextElement("Filename", m_image->filename());
+    xmlWriter.writeTextElement("Filename", m_image->id());
     xmlWriter.writeTextElement("BandID", QString::number(m_bandId));
     xmlWriter.writeEndElement();
 }
@@ -352,7 +352,7 @@ bool ImageBandParameter<T>::deserialize(QXmlStreamReader& xmlReader)
                         
                         for(Image<T>* allowed: m_allowed_images)
                         {
-                            if (allowed->filename() == valueText)
+                            if (allowed->id() == valueText)
                             {
                                 setImage(allowed);
                                 success = true;

--- a/src/modules/images/imagebandparameter.cxx
+++ b/src/modules/images/imagebandparameter.cxx
@@ -34,6 +34,7 @@
 /************************************************************************/
 
 #include "images/imagebandparameter.hxx"
+#include "core/globals.hxx"
 
 namespace graipe {
 
@@ -276,14 +277,14 @@ QString ImageBandParameter<T>::toString() const
 template <class T>
 void ImageBandParameter<T>::refresh()
 {
-    if(m_modelList && m_cmbImage)
+    if(models.size() && m_cmbImage)
 	{
 		m_allowed_images.clear();
 		m_cmbImage->clear();
 		
         Image<T> temp;
 		
-        for(Model* model : *m_modelList)
+        for(Model* model : models)
 		{
         	if(model->typeName() == temp.typeName())
 			{

--- a/src/modules/images/imagebandparameter.cxx
+++ b/src/modules/images/imagebandparameter.cxx
@@ -329,51 +329,67 @@ void ImageBandParameter<T>::serialize(QXmlStreamWriter& xmlWriter) const
 template <class T>
 bool ImageBandParameter<T>::deserialize(QXmlStreamReader& xmlReader)
 {
-//TODO!!!
-/**
-    if (!Parameter::deserialize(in))
+    bool success = false;
+    
+    try
     {
+        if (xmlReader.readNextStartElement())
+        {            
+            if(xmlReader.name() == magicID())
+            {
+                for(int i=0; i!=3; ++i)
+                {
+                    xmlReader.readNextStartElement();
+                
+                    if(xmlReader.name() == "Name")
+                    {
+                        setName(xmlReader.readElementText());
+                    }
+                    if(xmlReader.name() == "Filename")
+                    {
+                        QString valueText =  xmlReader.readElementText();
+                        
+                        for(Image<T>* allowed: m_allowed_images)
+                        {
+                            if (allowed->filename() == valueText)
+                            {
+                                setImage(allowed);
+                                success = true;
+                            }
+                        }
+                    }
+                    if(xmlReader.name() == "BandID")
+                    {
+                        QString valueText =  xmlReader.readElementText();
+                        setBandId(valueText.toInt());
+                    }
+                }
+                while(true)
+                {
+                    if(!xmlReader.readNext())
+                    {
+                        return false;
+                    }
+                    
+                    if(xmlReader.isEndElement() && xmlReader.name() == magicID())
+                    {
+                        break;
+                    }
+                }
+                return success;
+            }
+        }
+        else
+        {
+            throw std::runtime_error("Did not find magicID in XML tree");
+        }
+        throw std::runtime_error("Did not find any start element in XML tree");
+    }
+    catch(std::runtime_error & e)
+    {
+        qCritical() << magicID() << "::deserialize failed! Was looking for magicID: " << magicID() << "Error: " << e.what();
         return false;
     }
-    
-    bool found = false;
-    unsigned int i=0;
-    
-    QString content(in.readLine());
-    
-    QStringList fname_bandId = split_string_once(content, ", ");
-    
-    if(fname_bandId.size() ==2)
-    {
-        QString filename = decode_string(fname_bandId[0]);
-        unsigned int bandId = fname_bandId[1].toUInt();
-    
-        for(Image<T>* image: m_allowed_images)
-        {
-            if(image->filename() == filename && image->numBands() > bandId)
-            {
-                m_image = image;
-                m_bandId = bandId;
-                
-                if(m_cmbImage != NULL)
-                {
-                    m_cmbImage->setCurrentIndex(i);
-                    m_spbBand->setValue(bandId);
-                }
-                found = true;
-            }
-            i++;
-        }
-        
-        if (!found)
-        {
-            qDebug() << "ImageBandParameter deserialize: filename does not match any given or bandId was erroneous! Was:'" << content << "'";
-        }
-        
-        return found;
-    }
-    */
-    return false;
 }
 
 /**

--- a/src/modules/images/imagebandparameter.cxx
+++ b/src/modules/images/imagebandparameter.cxx
@@ -298,6 +298,7 @@ void ImageBandParameter<T>::serialize(QXmlStreamWriter& xmlWriter) const
     xmlWriter.setAutoFormatting(true);
     
     xmlWriter.writeStartElement(typeName());
+    xmlWriter.writeAttribute("ID", id());
     xmlWriter.writeTextElement("Name", name());
     xmlWriter.writeTextElement("Filename", m_image->id());
     xmlWriter.writeTextElement("BandID", QString::number(m_bandId));
@@ -365,7 +366,7 @@ bool ImageBandParameter<T>::deserialize(QXmlStreamReader& xmlReader)
         }
         else
         {
-            throw std::runtime_error("Did not find typeName() in XML tree");
+            throw std::runtime_error("Did not find typeName() or id() in XML tree");
         }
         throw std::runtime_error("Did not find any start element in XML tree");
     }

--- a/src/modules/images/imagebandparameter.cxx
+++ b/src/modules/images/imagebandparameter.cxx
@@ -309,10 +309,15 @@ void ImageBandParameter<T>::refresh()
  * \return The serialization of the parameter's state.
  */
 template <class T>
-void ImageBandParameter<T>::serialize(QIODevice & out) const
-{
-    Parameter::serialize(out);
-    write_on_device(", " + encode_string(m_image->filename()) + ", " + m_bandId, out);
+void ImageBandParameter<T>::serialize(QXmlStreamWriter& xmlWriter) const
+{    
+    xmlWriter.setAutoFormatting(true);
+    
+    xmlWriter.writeStartElement(magicID());
+    xmlWriter.writeTextElement("Name", name());
+    xmlWriter.writeTextElement("Filename", m_image->filename());
+    xmlWriter.writeTextElement("BandID", QString::number(m_bandId));
+    xmlWriter.writeEndElement();
 }
 
 /**

--- a/src/modules/images/imagebandparameter.cxx
+++ b/src/modules/images/imagebandparameter.cxx
@@ -166,7 +166,6 @@ ImageBandParameter<T>::ImageBandParameter(QString name, Parameter* parent, bool 
         {
             if(model->typeName() ==typeName)
             {
-                qDebug() << "Adding image " << model->shortName() << " to model list";
                 m_allowed_images.push_back(static_cast<Image<T>*>(model));
             }
         }
@@ -462,7 +461,7 @@ template <class T>
 void ImageBandParameter<T>::handleUpdateImage()
 {
     if(m_delegate != NULL)
-        {
+    {
         int idx = m_cmbImage->currentIndex();
             
         if(idx>=0 && idx<(int)m_allowed_images.size())

--- a/src/modules/images/imagebandparameter.cxx
+++ b/src/modules/images/imagebandparameter.cxx
@@ -73,7 +73,7 @@ ImageBandParameterBase::~ImageBandParameterBase()
  *
  * \return "ImageBandParameterBase".
  */
-QString ImageBandParameterBase::typeName()
+QString ImageBandParameterBase::typeName() const
 {
 	return "ImageBandParameterBase";
 }
@@ -156,11 +156,15 @@ ImageBandParameter<T>::ImageBandParameter(QString name, Parameter* parent, bool 
     if(models.size())
     {
         m_allowed_images.clear();
-        Image<T> temp;
-            
+        
+        Image<T> * img = new Image<T>;
+        QString typeName = img->typeName();
+        delete img;
+        img=NULL;
+        
         for(Model* model : models)
         {
-            if(model->typeName() == temp.typeName())
+            if(model->typeName() ==typeName)
             {
                 qDebug() << "Adding image " << model->shortName() << " to model list";
                 m_allowed_images.push_back(static_cast<Image<T>*>(model));
@@ -186,10 +190,10 @@ ImageBandParameter<T>::~ImageBandParameter()
 /**
  * The (immutable) type name of this parameter class.
  *
- * \return Image<T>::typeName() + "BandParameter".
+ * \return Image<T>::typeName() const + "BandParameter".
  */
 template <class T>
-QString ImageBandParameter<T>::typeName()
+QString ImageBandParameter<T>::typeName() const
 {
     Image<T> temp;
 	return temp.typeName() + "BandParameter";

--- a/src/modules/images/imagebandparameter.hxx
+++ b/src/modules/images/imagebandparameter.hxx
@@ -207,13 +207,6 @@ class GRAIPE_IMAGES_EXPORT ImageBandParameter
          */
         QString toString() const;
     
-        /**
-         * This method is called after each (re-)assignment of the model list
-         * e.g. after a call of the setModelList() function. 
-         * It synchronizes the list of available models with the widget's list.
-         */
-        void refresh();
-    
 	    /**
          * Serialization of the parameter's state to a string. Please note, that this can 
          * vary from the toString() result, which also returns a string. This is due to the fact,
@@ -259,6 +252,13 @@ class GRAIPE_IMAGES_EXPORT ImageBandParameter
         virtual bool isValid() const;
         
     protected:
+        /**
+         * Initializes the connections (signal<->slot) between the parameter class and
+         * the delegate widget. This will be done after the first call of the delegate()
+         * function, since the delegate is NULL until then.
+         */
+        void initConnections();
+        
         /**
          * This slot is called everytime, the delegate has changed. It has to synchronize
          * the internal value of the parameter with the current delegate's value

--- a/src/modules/images/imagebandparameter.hxx
+++ b/src/modules/images/imagebandparameter.hxx
@@ -221,7 +221,7 @@ class GRAIPE_IMAGES_EXPORT ImageBandParameter
          *
          * \return The serialization of the parameter's state.
          */
-        void serialize(QIODevice& out) const;
+        void serialize(QXmlStreamWriter& xmlWriter) const;
     
         /**
          * Deserialization of a parameter's state from a string.

--- a/src/modules/images/imagebandparameter.hxx
+++ b/src/modules/images/imagebandparameter.hxx
@@ -75,7 +75,7 @@ class GRAIPE_IMAGES_EXPORT ImageBandParameterBase
          *
          * \return "ImageBandParameterBase".
          */
-        QString typeName() const;
+        static QString typeName();
         
         /**
          * The delegate widget of this parameter. 
@@ -160,7 +160,7 @@ class GRAIPE_IMAGES_EXPORT ImageBandParameter
          *
          * \return "ImageBandParameter".
          */
-        QString typeName() const;        
+        static QString typeName();        
     
         /**
          * The current value of this parameter in the correct, most special type.

--- a/src/modules/images/imagebandparameter.hxx
+++ b/src/modules/images/imagebandparameter.hxx
@@ -75,7 +75,7 @@ class GRAIPE_IMAGES_EXPORT ImageBandParameterBase
          *
          * \return "ImageBandParameterBase".
          */
-        static QString typeName();
+        virtual QString typeName() const;
         
         /**
          * The delegate widget of this parameter. 
@@ -160,7 +160,7 @@ class GRAIPE_IMAGES_EXPORT ImageBandParameter
          *
          * \return "ImageBandParameter".
          */
-        static QString typeName();        
+        virtual QString typeName() const;        
     
         /**
          * The current value of this parameter in the correct, most special type.

--- a/src/modules/images/imagebandparameter.hxx
+++ b/src/modules/images/imagebandparameter.hxx
@@ -205,7 +205,7 @@ class GRAIPE_IMAGES_EXPORT ImageBandParameter
          *
          * \return The value of the parameter converted to an QString.
          */
-        QString valueText() const;
+        QString toString() const;
     
         /**
          * This method is called after each (re-)assignment of the model list
@@ -216,7 +216,7 @@ class GRAIPE_IMAGES_EXPORT ImageBandParameter
     
 	    /**
          * Serialization of the parameter's state to a string. Please note, that this can 
-         * vary from the valueText() result, which also returns a string. This is due to the fact,
+         * vary from the toString() result, which also returns a string. This is due to the fact,
          * that serialize also may perform encoding of strings to avoid special chars.
          *
          * \return The serialization of the parameter's state.
@@ -229,7 +229,7 @@ class GRAIPE_IMAGES_EXPORT ImageBandParameter
          * \param str The serialization of this parameter's state.
          * \return True, if the deserialization was successful, else false.
          */
-        bool deserialize(QIODevice& in);
+        bool deserialize(QXmlStreamReader& xmlReader);
     
         /**
          * This function locks the parameters value. 

--- a/src/modules/images/imageimpex.cxx
+++ b/src/modules/images/imageimpex.cxx
@@ -658,7 +658,7 @@ ImageExporter::ImageExporter()
 		format_names.append("JPEG"); format_names.append("netCDF");
 		format_names.append("PNG"); format_names.append("XYZ");
 
-    m_parameters->addParameter("image", new ModelParameter("Image",	NULL,  "Image, IntImage, ByteImage"));
+    m_parameters->addParameter("image", new ModelParameter("Image",	"Image, IntImage, ByteImage"));
     m_parameters->addParameter("filename", new FilenameParameter("Image filename", "", NULL));
     m_parameters->addParameter("format", new EnumParameter("File format", format_names));
 }

--- a/src/modules/images/imageimpex.cxx
+++ b/src/modules/images/imageimpex.cxx
@@ -682,20 +682,20 @@ void ImageExporter::run()
         {
             res = ImageImpex::exportImage(*static_cast<Image<float>*>(param_image->value()),
                                           param_filename->value(),
-                                          param_fileformat->valueText());
+                                          param_fileformat->toString());
         }
         
         if(param_image->value()->typeName() == "IntImage")
         {
             res = ImageImpex::exportImage(*static_cast<Image<int>*>(param_image->value()),
                                           param_filename->value(),
-                                          param_fileformat->valueText());
+                                          param_fileformat->toString());
         }
         else if(param_image->value()->typeName() == "ByteImage")
         {
             res = ImageImpex::exportImage(*static_cast<Image<unsigned char>*>(param_image->value()),
                                           param_filename->value(),
-                                          param_fileformat->valueText());
+                                          param_fileformat->toString());
         }
         
         if(res)

--- a/src/modules/images/imageimpex.cxx
+++ b/src/modules/images/imageimpex.cxx
@@ -612,18 +612,15 @@ void ImageImporter::run()
         else 
         {
             emit errorMessage(QString("Explainable error occured: Image could not be imported"));
-            m_results.clear();
         }
     }
     catch(std::exception& e)
     {
         emit errorMessage(QString("Explainable error occured: ") + QString::fromStdString(e.what()));
-        m_results.clear();
     }
     catch(...)
     {
-        emit errorMessage(QString("Non-explainable error occured"));		
-        m_results.clear();
+        emit errorMessage(QString("Non-explainable error occured"));
     }
 }
 
@@ -633,7 +630,9 @@ void ImageImporter::run()
  */
 void ImageImporter::pixelTypeChanged()
 {
+    delete m_results[0];
     m_results.clear();
+    
     switch(m_pixeltype->value())
     {
         case 0:

--- a/src/modules/images/imageimpex.cxx
+++ b/src/modules/images/imageimpex.cxx
@@ -437,7 +437,7 @@ bool ImageImpex::importImage(const QString & filename, Image<T>& image)
 				global_bottom = global_top  + (global_bottom - global_top)*rescale.second;
 				
 				//Set filename in each case!
-				image.setFilename(filename);
+				image.setID(filename);
 				
                 QFileInfo fi(filename);
                 

--- a/src/modules/images/imageviewcontroller.cxx
+++ b/src/modules/images/imageviewcontroller.cxx
@@ -136,7 +136,7 @@ void ImageSingleBandViewController<T>::paint(QPainter *painter, const QStyleOpti
  *         "ByteImageSingleBandViewController".
  */
 template <class T>
-QString ImageSingleBandViewController<T>::typeName() const
+QString ImageSingleBandViewController<T>::typeName()
 {
     Image<T> temp;
     
@@ -324,7 +324,7 @@ void ImageRGBViewController<T>::paint(QPainter *painter, const QStyleOptionGraph
  *         "ByteImageRGBViewController".
  */
 template <class T>
-QString ImageRGBViewController<T>::typeName() const
+QString ImageRGBViewController<T>::typeName()
 {
     Image<T> temp;
     

--- a/src/modules/images/imageviewcontroller.cxx
+++ b/src/modules/images/imageviewcontroller.cxx
@@ -136,10 +136,9 @@ void ImageSingleBandViewController<T>::paint(QPainter *painter, const QStyleOpti
  *         "ByteImageSingleBandViewController".
  */
 template <class T>
-QString ImageSingleBandViewController<T>::typeName()
+QString ImageSingleBandViewController<T>::typeName() const
 {
     Image<T> temp;
-    
     return temp.typeName() + "SingleBandViewController";
 }
 /**
@@ -324,10 +323,10 @@ void ImageRGBViewController<T>::paint(QPainter *painter, const QStyleOptionGraph
  *         "ByteImageRGBViewController".
  */
 template <class T>
-QString ImageRGBViewController<T>::typeName()
+QString ImageRGBViewController<T>::typeName() const
 {
     Image<T> temp;
-    
+
     return temp.typeName() + "RGBViewController";
 }
 

--- a/src/modules/images/imageviewcontroller.hxx
+++ b/src/modules/images/imageviewcontroller.hxx
@@ -85,7 +85,7 @@ class GRAIPE_IMAGES_EXPORT ImageSingleBandViewController
          *         "ImageSingleBandViewController", "IntImageSingleBandViewController" or
          *         "ByteImageSingleBandViewController".
          */
-        QString typeName() const;
+        static QString typeName();
     
         /**
          * Specialization of the update of the view according to the current parameter settings.
@@ -171,7 +171,7 @@ class GRAIPE_IMAGES_EXPORT ImageRGBViewController
          *         "ImageRGBViewController", "IntImageRGBViewController" or
          *         "ByteImageRGBViewController".
          */
-        QString typeName() const;
+        static QString typeName();
     
         /**
          * Specialization of the update of the view according to the current parameter settings.

--- a/src/modules/images/imageviewcontroller.hxx
+++ b/src/modules/images/imageviewcontroller.hxx
@@ -85,7 +85,7 @@ class GRAIPE_IMAGES_EXPORT ImageSingleBandViewController
          *         "ImageSingleBandViewController", "IntImageSingleBandViewController" or
          *         "ByteImageSingleBandViewController".
          */
-        static QString typeName();
+        virtual QString typeName() const;
     
         /**
          * Specialization of the update of the view according to the current parameter settings.
@@ -171,7 +171,7 @@ class GRAIPE_IMAGES_EXPORT ImageRGBViewController
          *         "ImageRGBViewController", "IntImageRGBViewController" or
          *         "ByteImageRGBViewController".
          */
-        static QString typeName();
+        virtual QString typeName() const;
     
         /**
          * Specialization of the update of the view according to the current parameter settings.

--- a/src/modules/images/imageviewcontroller.hxx
+++ b/src/modules/images/imageviewcontroller.hxx
@@ -111,7 +111,6 @@ class GRAIPE_IMAGES_EXPORT ImageSingleBandViewController
         FloatParameter*  m_maxValue;
         BoolParameter*   m_transparentAboveMax;
         ColorTableParameter*  m_colorTable;
-        EnumParameter*   m_scalingFunction;
         IntParameter*    m_bandId;
         BoolParameter*   m_showIntensityLegend;
         StringParameter* m_legendCaption;
@@ -194,7 +193,6 @@ class GRAIPE_IMAGES_EXPORT ImageRGBViewController
         BoolParameter*  m_transparentBelowMin;
         FloatParameter* m_maxValue;
         BoolParameter*  m_transparentAboveMax;
-        EnumParameter*  m_scalingFunction;
         IntParameter*   m_redBandId;
         IntParameter*   m_greenBandId;
         IntParameter*   m_blueBandId;

--- a/src/modules/multispectral/multispectralmodule.cxx
+++ b/src/modules/multispectral/multispectralmodule.cxx
@@ -73,7 +73,7 @@ class MSCannyFeatureDetector
          */
         MSCannyFeatureDetector()
         {
-            m_parameters->addParameter("image", new ModelParameter("Image", NULL,"Image"));
+            m_parameters->addParameter("image", new ModelParameter("Image","Image"));
             m_parameters->addParameter("sigma", new FloatParameter("Canny Scale", 0,9999999, 0));
             m_parameters->addParameter("T", new FloatParameter("Canny (gradient strength) threshold", 0,9999999, 0));
             m_parameters->addParameter("mode", new EnumParameter("MS gradient mode:", ms_gradient_modes(),0));
@@ -184,7 +184,7 @@ class MSGradientCalculator
          */
         MSGradientCalculator()
         {
-            m_parameters->addParameter("image", new ModelParameter("Image", NULL,"Image"));
+            m_parameters->addParameter("image", new ModelParameter("Image","Image"));
             m_parameters->addParameter("sigma", new FloatParameter("Gradient Scale", 0,9999999, 0));
         }
     
@@ -297,7 +297,7 @@ class NDVIEstimator
          */
         NDVIEstimator()
         {
-            m_parameters->addParameter("image", new ModelParameter("Image", NULL,"Image"));
+            m_parameters->addParameter("image", new ModelParameter("Image","Image"));
             m_parameters->addParameter("red-id", new IntParameter("Red band-id", 0,9999999, 2));
             m_parameters->addParameter("nir-id", new IntParameter("NIR band-id", 0,9999999, 3));
         }
@@ -395,7 +395,7 @@ class EVIEstimator
          */
         EVIEstimator()
         {
-            m_parameters->addParameter("image", new ModelParameter("Image", NULL,"Image"));
+            m_parameters->addParameter("image", new ModelParameter("Image","Image"));
             m_parameters->addParameter("blue-id", new IntParameter("Blue band-id", 0,9999999, 0));
             m_parameters->addParameter("red-id", new IntParameter("Red band-id", 0,9999999, 2));
             m_parameters->addParameter("nir-id", new IntParameter("NIR band-id", 0,9999999, 3));
@@ -509,7 +509,7 @@ class EVI2BandsEstimator
          */
         EVI2BandsEstimator()
         {
-            m_parameters->addParameter("image", new ModelParameter("Image", NULL,"Image"));
+            m_parameters->addParameter("image", new ModelParameter("Image","Image"));
             m_parameters->addParameter("red-id", new IntParameter("Red band-id", 0,9999999, 2));
             m_parameters->addParameter("nir-id", new IntParameter("NIR band-id", 0,9999999, 3));
             

--- a/src/modules/multispectral/multispectralopticalflowalgorithms.hxx
+++ b/src/modules/multispectral/multispectralopticalflowalgorithms.hxx
@@ -66,10 +66,10 @@ class OpticalFlowAlgorithm2Bands
          */
         void addImageAndMaskParameters()
         {
-            m_param_image1		= new ModelParameter("Reference Image",	NULL,  "Image");
+            m_param_image1		= new ModelParameter("Reference Image",  "Image");
             m_param_image1Band1	= new IntParameter("Reference Image band 1", 0, 200,0);
             m_param_image1Band2	= new IntParameter("Reference Image band 2", 0, 200,0);
-            m_param_image2		= new ModelParameter("Second Image",	NULL,  "Image");
+            m_param_image2		= new ModelParameter("Second Image", "Image");
             m_param_image2Band1	= new IntParameter("Second Image band 1", 0, 200,0);
             m_param_image2Band2	= new IntParameter("Second Image band 2", 0, 200,0);
             

--- a/src/modules/opticalflow/opticalflowalgorithms.hxx
+++ b/src/modules/opticalflow/opticalflowalgorithms.hxx
@@ -303,11 +303,11 @@ class OpticalFlowAlgorithm
                     
                     if( i != 0)
                     {
-                        new_vectorfield->setName(QString("%1 (L%2) of %3 and %4").arg(functor_sname).arg(i).arg(m_param_imageBand1->valueText()).arg(m_param_imageBand2->valueText()));
+                        new_vectorfield->setName(QString("%1 (L%2) of %3 and %4").arg(functor_sname).arg(i).arg(m_param_imageBand1->toString()).arg(m_param_imageBand2->toString()));
                     }
                     else
                     {
-                        new_vectorfield->setName(QString("%1 of %2 and %3").arg(functor_sname).arg(m_param_imageBand1->valueText()).arg(m_param_imageBand2->valueText()));
+                        new_vectorfield->setName(QString("%1 of %2 and %3").arg(functor_sname).arg(m_param_imageBand1->toString()).arg(m_param_imageBand2->toString()));
                     }
                     new_vectorfield->setGlobalMotion(QTransform(mat_list[i](0,0), mat_list[i](1,0), mat_list[i](2,0),
                                                                 mat_list[i](0,1), mat_list[i](1,1), mat_list[i](2,1),
@@ -342,7 +342,7 @@ class OpticalFlowAlgorithm
                     
                     m_param_imageBand1->image()->copyMetadata(*new_image);
                     
-                    new_image->setName(QString("Warped Image (L%1) of %2").arg(i).arg(m_param_imageBand1->valueText()));
+                    new_image->setName(QString("Warped Image (L%1) of %2").arg(i).arg(m_param_imageBand1->toString()));
                     new_image->setDescription(QString(  "The following parameters were used to calculate the warping:\n"
                                                         "TPS Functor\n"
                                                         "Subsampled each %1 pixel").arg(5*m_param_pmode->value()));

--- a/src/modules/racerclient/racerclientmodule.cxx
+++ b/src/modules/racerclient/racerclientmodule.cxx
@@ -79,7 +79,7 @@ class RacerInterpreter
          */
         RacerInterpreter()
         { 
-            m_param_measured_vectorfield = new ModelParameter("Derived Current Vectorfield", NULL, "SparseVectorfield2D|SparseMultiVectorfield2D|SparseWeightedVectorfield2D|SparseWeightedMultiVectorfield2D|DenseVectorfield2D|DenseWeightedVectorfield2D");
+            m_param_measured_vectorfield = new ModelParameter("Derived Current Vectorfield", "SparseVectorfield2D|SparseMultiVectorfield2D|SparseWeightedVectorfield2D|SparseWeightedMultiVectorfield2D|DenseVectorfield2D|DenseWeightedVectorfield2D");
             m_param_tbox_filename = new FilenameParameter("T-Box in Racer-format");
             
             m_param_velocity1	=  new FloatParameter("low velocity [cm/s] <= ", 0,999999, 10);
@@ -91,10 +91,10 @@ class RacerInterpreter
             m_param_distance3 = new FloatParameter("far distance [km] <=", 0,999999, 10);
             
             m_param_use_wind = new BoolParameter("Wind vectorfield available?", false);
-            m_param_wind_vectorfield = new ModelParameter("Wind vectorfield", NULL, "SparseVectorfield2D|SparseMultiVectorfield2D|SparseWeightedVectorfield2D|SparseWeightedMultiVectorfield2D|DenseVectorfield2D|DenseWeightedVectorfield2D", NULL, m_param_use_wind);
+            m_param_wind_vectorfield = new ModelParameter("Wind vectorfield", "SparseVectorfield2D|SparseMultiVectorfield2D|SparseWeightedVectorfield2D|SparseWeightedMultiVectorfield2D|DenseVectorfield2D|DenseWeightedVectorfield2D", NULL, m_param_use_wind);
             
             m_param_use_modelled_currents = new BoolParameter("Modelled current available?", false);
-            m_param_modelled_vectorfield = new ModelParameter("Modelled current vectorfield", NULL, "SparseVectorfield2D|SparseMultiVectorfield2D|SparseWeightedVectorfield2D|SparseWeightedMultiVectorfield2D|DenseVectorfield2D|DenseWeightedVectorfield2D", NULL, m_param_use_modelled_currents);
+            m_param_modelled_vectorfield = new ModelParameter("Modelled current vectorfield", "SparseVectorfield2D|SparseMultiVectorfield2D|SparseWeightedVectorfield2D|SparseWeightedMultiVectorfield2D|DenseVectorfield2D|DenseWeightedVectorfield2D", NULL, m_param_use_modelled_currents);
 
             m_param_save_abox = new BoolParameter("Save resulting A-Box?", false);
             m_param_abox_filename = new FilenameParameter("A-Box in Racer-format", "", m_param_save_abox);	
@@ -701,8 +701,8 @@ class RacerClusteredInterpreter
          */
         RacerClusteredInterpreter()
         { 
-            m_param_measured_vectorfield = new ModelParameter("Clustered Current Vectorfield", NULL, "SparseVectorfield2D|SparseMultiVectorfield2D|SparseWeightedVectorfield2D|SparseWeightedMultiVectorfield2D|DenseVectorfield2D|DenseWeightedVectorfield2D");
-            m_param_clusters = new ModelParameter("Weighted Cluster borders", NULL, "WeightedPolygonList2D");
+            m_param_measured_vectorfield = new ModelParameter("Clustered Current Vectorfield", "SparseVectorfield2D|SparseMultiVectorfield2D|SparseWeightedVectorfield2D|SparseWeightedMultiVectorfield2D|DenseVectorfield2D|DenseWeightedVectorfield2D");
+            m_param_clusters = new ModelParameter("Weighted Cluster borders", "WeightedPolygonList2D");
             m_param_tbox_filename = new FilenameParameter("T-Box in Racer-format");
             
             m_param_smoothness_threshold	=  new FloatParameter("smoothness threshold ", 0,999999, 10);
@@ -716,10 +716,10 @@ class RacerClusteredInterpreter
             m_param_distance3 = new FloatParameter("far distance [km] <=", 0,999999, 10);
             
             m_param_use_wind = new BoolParameter("Wind vectorfield available?", false);
-            m_param_wind_vectorfield = new ModelParameter("Wind vectorfield", NULL, "SparseVectorfield2D|SparseMultiVectorfield2D|SparseWeightedVectorfield2D|SparseWeightedMultiVectorfield2D|DenseVectorfield2D|DenseWeightedVectorfield2D", NULL, m_param_use_wind);
+            m_param_wind_vectorfield = new ModelParameter("Wind vectorfield", "SparseVectorfield2D|SparseMultiVectorfield2D|SparseWeightedVectorfield2D|SparseWeightedMultiVectorfield2D|DenseVectorfield2D|DenseWeightedVectorfield2D", NULL, m_param_use_wind);
             
             m_param_use_modelled_currents = new BoolParameter("Modelled current available?", false);
-            m_param_modelled_vectorfield = new ModelParameter("Modelled current vectorfield", NULL, "SparseVectorfield2D|SparseMultiVectorfield2D|SparseWeightedVectorfield2D|SparseWeightedMultiVectorfield2D|DenseVectorfield2D|DenseWeightedVectorfield2D", NULL, m_param_use_modelled_currents);
+            m_param_modelled_vectorfield = new ModelParameter("Modelled current vectorfield", "SparseVectorfield2D|SparseMultiVectorfield2D|SparseWeightedVectorfield2D|SparseWeightedMultiVectorfield2D|DenseVectorfield2D|DenseWeightedVectorfield2D", NULL, m_param_use_modelled_currents);
 
             m_param_save_abox = new BoolParameter("Save resulting A-Box?", false);
             m_param_abox_filename = new FilenameParameter("A-Box in Racer-format", "", m_param_save_abox);	
@@ -1330,8 +1330,8 @@ class ClusteredABox
          */
         ClusteredABox()
         { 
-            m_param_measured_vectorfield = new ModelParameter("Clustered Current Vectorfield", NULL, "SparseVectorfield2D|SparseMultiVectorfield2D|SparseWeightedVectorfield2D|SparseWeightedMultiVectorfield2D|DenseVectorfield2D|DenseWeightedVectorfield2D");
-            m_param_clusters = new ModelParameter("Weighted Cluster borders", NULL, "WeightedPolygonList2D");
+            m_param_measured_vectorfield = new ModelParameter("Clustered Current Vectorfield", "SparseVectorfield2D|SparseMultiVectorfield2D|SparseWeightedVectorfield2D|SparseWeightedMultiVectorfield2D|DenseVectorfield2D|DenseWeightedVectorfield2D");
+            m_param_clusters = new ModelParameter("Weighted Cluster borders", "WeightedPolygonList2D");
             
             m_param_smoothness_threshold	=  new FloatParameter("smoothness threshold ", 0,999999, 10);
             
@@ -1344,10 +1344,10 @@ class ClusteredABox
             m_param_distance3 = new FloatParameter("far distance [km] <=", 0,999999, 10);
             
             m_param_use_wind = new BoolParameter("Wind vectorfield available?", false);
-            m_param_wind_vectorfield = new ModelParameter("Wind vectorfield", NULL, "SparseVectorfield2D|SparseMultiVectorfield2D|SparseWeightedVectorfield2D|SparseWeightedMultiVectorfield2D|DenseVectorfield2D|DenseWeightedVectorfield2D", NULL, m_param_use_wind);
+            m_param_wind_vectorfield = new ModelParameter("Wind vectorfield", "SparseVectorfield2D|SparseMultiVectorfield2D|SparseWeightedVectorfield2D|SparseWeightedMultiVectorfield2D|DenseVectorfield2D|DenseWeightedVectorfield2D", NULL, m_param_use_wind);
             
             m_param_use_modelled_currents = new BoolParameter("Modelled current available?", false);
-            m_param_modelled_vectorfield = new ModelParameter("Modelled current vectorfield", NULL, "SparseVectorfield2D|SparseMultiVectorfield2D|SparseWeightedVectorfield2D|SparseWeightedMultiVectorfield2D|DenseVectorfield2D|DenseWeightedVectorfield2D", NULL, m_param_use_modelled_currents);
+            m_param_modelled_vectorfield = new ModelParameter("Modelled current vectorfield", "SparseVectorfield2D|SparseMultiVectorfield2D|SparseWeightedVectorfield2D|SparseWeightedMultiVectorfield2D|DenseVectorfield2D|DenseWeightedVectorfield2D", NULL, m_param_use_modelled_currents);
 
             m_param_abox_filename = new FilenameParameter("A-Box in Racer-format", "");	
             

--- a/src/modules/registration/registrationmodule.cxx
+++ b/src/modules/registration/registrationmodule.cxx
@@ -117,14 +117,14 @@ class GlobalMotionCorrector
                     
                     m_param_imageBand2->image()->copyMetadata(*displaced_image);
                     
-                    displaced_image->setName("GME corrected image band " + m_param_imageBand1->valueText());
+                    displaced_image->setName("GME corrected image band " + m_param_imageBand1->toString());
                     
                     
                     QTransform transform(mat(0,0), mat(1,0), mat(2,0),
                                          mat(0,1), mat(1,1), mat(2,1),
                                          mat(0,2), mat(1,2), mat(2,2));
 
-                    QString mat_str = TransformParameter::valueText(transform);
+                    QString mat_str = "";//TODO:TransformParameter::valueText(transform);
                     
                     qDebug() << "GME: Matrix=" << transform << "\nMatString="<< mat_str <<"\n";
                     
@@ -133,7 +133,7 @@ class GlobalMotionCorrector
                                             "Computed global motion matrix (I1 -> I2): %3\n"
                                             "rotation accuracy: %4\n"
                                             "translation accuracy: %5\n"
-                                            "processing time: %6 seconds").arg(m_param_imageBand1->valueText()).arg(m_param_imageBand2->valueText())
+                                            "processing time: %6 seconds").arg(m_param_imageBand1->toString()).arg(m_param_imageBand2->toString())
                                             .arg(mat_str).arg(rotation_correlation).arg(translation_correlation).arg(processing_time/1000.0);
                                         
                     displaced_image->setDescription(descr);

--- a/src/modules/registration/registrationmodule.cxx
+++ b/src/modules/registration/registrationmodule.cxx
@@ -190,9 +190,9 @@ class GenericRegistration
          */
 		GenericRegistration()
 		{
-			m_parameters->addParameter("image1", new ModelParameter("Image to be warped",	NULL,  "Image"));
-			m_parameters->addParameter("image2", new ModelParameter("Reference Image",	NULL,  "Image"));
-			m_parameters->addParameter("vf", new ModelParameter("Correspondence Map",	NULL,  "SparseVectorfield2D"));
+			m_parameters->addParameter("image1", new ModelParameter("Image to be warped",  "Image"));
+			m_parameters->addParameter("image2", new ModelParameter("Reference Image",  "Image"));
+			m_parameters->addParameter("vf", new ModelParameter("Correspondence Map",  "SparseVectorfield2D"));
 		}
 
         /**

--- a/src/modules/vectorfieldprocessing/vectorfieldprocessingmodule.cxx
+++ b/src/modules/vectorfieldprocessing/vectorfieldprocessingmodule.cxx
@@ -53,7 +53,7 @@ class VectorfieldSmoother
          */
         VectorfieldSmoother()
         {
-            m_parameters->addParameter("vf",               new ModelParameter("Vectorfield",	NULL,  "SparseWeightedMultiVectorfield2D"));
+            m_parameters->addParameter("vf",               new ModelParameter("Vectorfield", "SparseWeightedMultiVectorfield2D"));
             m_parameters->addParameter("radius",           new FloatParameter("radius for smoothing", 0.0, 9999, 10));
             m_parameters->addParameter("weightT",          new FloatParameter("weight threshold", 0.0, 9999, 0.0));
             m_parameters->addParameter("iterations",       new IntParameter("iterations", 1, 9999, 10));
@@ -145,7 +145,7 @@ class VectorfieldRelaxer : public Algorithm
          */
         VectorfieldRelaxer()
         {
-            m_parameters->addParameter("vf",               new ModelParameter("Vectorfield",	NULL,  "SparseWeightedMultiVectorfield2D"));
+            m_parameters->addParameter("vf",               new ModelParameter("Vectorfield", "SparseWeightedMultiVectorfield2D"));
             m_parameters->addParameter("radius",           new FloatParameter("radius for smoothing", 0.0, 9999, 10));
             m_parameters->addParameter("weightT",          new FloatParameter("weight threshold", 0.0, 9999, 0.0));
             m_parameters->addParameter("iterations",       new IntParameter("iterations", 1, 9999, 10));
@@ -237,7 +237,7 @@ class VectorfieldClustererGreedy : public Algorithm
          */
         VectorfieldClustererGreedy()
         {
-            m_parameters->addParameter("vf",  new ModelParameter("Vectorfield",	NULL,  "SparseWeightedVectorfield2D|SparseWeightedMultiVectorfield2D"));
+            m_parameters->addParameter("vf",  new ModelParameter("Vectorfield", "SparseWeightedVectorfield2D|SparseWeightedMultiVectorfield2D"));
             m_parameters->addParameter("weight-dir", new FloatParameter("weight direction for clustering", 0.0, 9999, 1.0));
             m_parameters->addParameter("radius", new FloatParameter("radius for clustering sizes", 0.0, 9999, 10));
             m_parameters->addParameter("weightT", new FloatParameter("weight threshold", 0.0, 9999, 0.0));
@@ -343,7 +343,7 @@ class VectorfieldClustererKMeans
          */
         VectorfieldClustererKMeans()
         {
-            m_parameters->addParameter("vf", new ModelParameter("Vectorfield",	NULL,  "SparseWeightedVectorfield2D|SparseWeightedMultiVectorfield2D"));
+            m_parameters->addParameter("vf", new ModelParameter("Vectorfield", "SparseWeightedVectorfield2D|SparseWeightedMultiVectorfield2D"));
             m_parameters->addParameter("weight-dir", new FloatParameter("weight direction for clustering", 0.0, 9999, 1.0));
             m_parameters->addParameter("k", new IntParameter("k (count of clusters)", 0.0, 9999, 10));
             m_parameters->addParameter("weightT",  new FloatParameter("weight threshold", 0.0, 9999, 0.0));

--- a/src/modules/vectorfields/densevectorfield.cxx
+++ b/src/modules/vectorfields/densevectorfield.cxx
@@ -105,7 +105,7 @@ DenseVectorfield2D::DenseVectorfield2D(const ArrayViewType & u, const ArrayViewT
  *
  * \return Always "DenseVectorfield2D"
  */
-QString DenseVectorfield2D::typeName()
+QString DenseVectorfield2D::typeName() const
 { 
     return	QString("DenseVectorfield2D");
 }
@@ -804,7 +804,7 @@ DenseWeightedVectorfield2D::DenseWeightedVectorfield2D(const ArrayViewType& u, c
  *
  * \return Always "DenseWeightedVectorfield2D"
  */
-QString DenseWeightedVectorfield2D::typeName()
+QString DenseWeightedVectorfield2D::typeName() const
 { 
 	return QString("DenseWeightedVectorfield2D");
 }

--- a/src/modules/vectorfields/densevectorfield.cxx
+++ b/src/modules/vectorfields/densevectorfield.cxx
@@ -105,7 +105,7 @@ DenseVectorfield2D::DenseVectorfield2D(const ArrayViewType & u, const ArrayViewT
  *
  * \return Always "DenseVectorfield2D"
  */
-QString DenseVectorfield2D::typeName() const
+QString DenseVectorfield2D::typeName()
 { 
     return	QString("DenseVectorfield2D");
 }
@@ -804,7 +804,7 @@ DenseWeightedVectorfield2D::DenseWeightedVectorfield2D(const ArrayViewType& u, c
  *
  * \return Always "DenseWeightedVectorfield2D"
  */
-QString DenseWeightedVectorfield2D::typeName() const
+QString DenseWeightedVectorfield2D::typeName()
 { 
 	return QString("DenseWeightedVectorfield2D");
 }

--- a/src/modules/vectorfields/densevectorfield.cxx
+++ b/src/modules/vectorfields/densevectorfield.cxx
@@ -580,9 +580,10 @@ void DenseVectorfield2D::serialize_content(QXmlStreamWriter& xmlWriter) const
  * \param in The QIODevice, where we will read from.
  * \return True, if the content could be deserialized and the model is not locked.
  */
-bool DenseVectorfield2D::deserialize_content(QIODevice& in)
+bool DenseVectorfield2D::deserialize_content(QXmlStreamReader& xmlReader)
 {
-    if(width() == 0 || height()==0)
+ //TODO!!!
+/**   if(width() == 0 || height()==0)
     {
         qCritical("DenseVectorfield2D::deserialize_content: storage image has zero size!");
         return false;
@@ -611,6 +612,8 @@ bool DenseVectorfield2D::deserialize_content(QIODevice& in)
     }
     
     return true;
+    **/
+    return false;
 }
 
 /**
@@ -894,9 +897,10 @@ void DenseWeightedVectorfield2D::serialize_content(QXmlStreamWriter& xmlWriter) 
  * \param in The QIODevice, where we will read from.
  * \return True, if the content could be deserialized and the model is not locked.
  */
-bool DenseWeightedVectorfield2D::deserialize_content(QIODevice& in)
+bool DenseWeightedVectorfield2D::deserialize_content(QXmlStreamReader& xmlReader)
 {
-    if( !DenseVectorfield2D::deserialize_content(in))
+//TODO!!!
+/**    if( !DenseVectorfield2D::deserialize_content(in))
     {
         return false;
     }
@@ -914,6 +918,8 @@ bool DenseWeightedVectorfield2D::deserialize_content(QIODevice& in)
     }
 
     return true;
+    **/
+    return false;
 }
 
 

--- a/src/modules/vectorfields/densevectorfield.cxx
+++ b/src/modules/vectorfields/densevectorfield.cxx
@@ -546,7 +546,7 @@ void DenseVectorfield2D::setV(const ArrayViewType& new_v)
 }
 
 /**
- * Serialize the complete content of the dense vectorfield to a QIODevice.
+ * Serialize the complete content of the dense vectorfield to an xml file.
  * The serialization is just a binary stream of m_u followed by m_v.
  *
  * \param out The output device for serialization.
@@ -581,11 +581,11 @@ void DenseVectorfield2D::serialize_content(QXmlStreamWriter& xmlWriter) const
 }
 
 /**
- * Deserializion of a  dense vectorfield from a QIODevice.
+ * Deserialization of a  dense vectorfield from an xml file.
  * Since the serialization is just a binary stream of m_u and m_v
  * and we already know the size, it is quite easy the deserialize.
  *
- * \param in The QIODevice, where we will read from.
+ * \param xmlReader The QXmlStreamReader, where we will read from.
  * \return True, if the content could be deserialized and the model is not locked.
  */
 bool DenseVectorfield2D::deserialize_content(QXmlStreamReader& xmlReader)
@@ -911,7 +911,7 @@ void DenseWeightedVectorfield2D::setWeight(unsigned int x, unsigned int y, float
 }
 
 /**
- * Serialize the complete content of the dense weighted vectorfield to a QIODevice.
+ * Serialize the complete content of the dense weighted vectorfield to an xml file.
  * The serialization is just a binary stream of m_u followed by m_v and m_w.
  *
  * \param out The output device for serialization.
@@ -939,11 +939,11 @@ void DenseWeightedVectorfield2D::serialize_content(QXmlStreamWriter& xmlWriter) 
 }
 
 /**
- * Deserializion of a  dense vectorfield from a QIODevice.
+ * Deserialization of a  dense vectorfield from an xml file.
  * Since the serialization is just a binary stream of m_u, m_v and m_w
  * and we already know the size, it is quite easy the deserialize.
  *
- * \param in The QIODevice, where we will read from.
+ * \param xmlReader The QXmlStreamReader, where we will read from.
  * \return True, if the content could be deserialized and the model is not locked.
  */
 bool DenseWeightedVectorfield2D::deserialize_content(QXmlStreamReader& xmlReader)

--- a/src/modules/vectorfields/densevectorfield.cxx
+++ b/src/modules/vectorfields/densevectorfield.cxx
@@ -551,10 +551,10 @@ void DenseVectorfield2D::setV(const ArrayViewType& new_v)
  *
  * \param out The output device for serialization.
  */
-void DenseVectorfield2D::serialize_content(QIODevice& out) const
+void DenseVectorfield2D::serialize_content(QXmlStreamWriter& xmlWriter) const
 {
-    qint64 channel_size = m_u.width()*m_u.height()*sizeof(ArrayType::value_type);
-    qint64 written_bytes;
+//TODO!!!    qint64 channel_size = m_u.width()*m_u.height()*sizeof(ArrayType::value_type);
+/*    qint64 written_bytes;
     
     //First write x-part of vectors: m_u
     written_bytes = out.write((const char*)m_u.data(),channel_size);
@@ -569,7 +569,7 @@ void DenseVectorfield2D::serialize_content(QIODevice& out) const
     {
        qCritical() << "DenseVectorfield2D::serialize_content: Error while writing y-part of vectors from m_v. Expected to write " << channel_size << "bytes, but only wrote " << written_bytes << " bytes";
     }
-
+*/
 }
 
 /**
@@ -871,10 +871,10 @@ void DenseWeightedVectorfield2D::setWeight(unsigned int x, unsigned int y, float
  *
  * \param out The output device for serialization.
  */
-void DenseWeightedVectorfield2D::serialize_content(QIODevice& out) const
+void DenseWeightedVectorfield2D::serialize_content(QXmlStreamWriter& xmlWriter) const
 {
-    DenseVectorfield2D::serialize_content(out);
-    
+//TODO!!!    DenseVectorfield2D::serialize_content(out);
+    /*
     qint64 channel_size = m_w.width()*m_w.height()*sizeof(ArrayType::value_type);
     
     //Write weights of vectors: m_w
@@ -883,6 +883,7 @@ void DenseWeightedVectorfield2D::serialize_content(QIODevice& out) const
     {
        qCritical() << "DenseWeightedVectorfield2D::serialize_content: Error while writing weights of vectors from m_w. Expected to write " << channel_size << "bytes, but only wrote " << written_bytes << " bytes";
     }
+    */
 }
 
 /**

--- a/src/modules/vectorfields/densevectorfield.hxx
+++ b/src/modules/vectorfields/densevectorfield.hxx
@@ -100,7 +100,7 @@ class GRAIPE_VECTORFIELDS_EXPORT DenseVectorfield2D
          *
          * \return Always "DenseVectorfield2D"
          */
-		static QString typeName();
+		virtual QString typeName() const;
 		
         /**
          * The size of this vectorfield. 
@@ -529,7 +529,7 @@ class GRAIPE_VECTORFIELDS_EXPORT DenseWeightedVectorfield2D : public DenseVector
          *
          * \return Always "DenseWeightedVectorfield2D"
          */
-		static QString typeName();
+		virtual QString typeName() const;
         
         /**
          * This does not remove all the vectors, but resets their directions 

--- a/src/modules/vectorfields/densevectorfield.hxx
+++ b/src/modules/vectorfields/densevectorfield.hxx
@@ -412,7 +412,7 @@ class GRAIPE_VECTORFIELDS_EXPORT DenseVectorfield2D
          *
          * \param out The output device for serialization.
          */
-		void serialize_content(QIODevice& out) const;
+		void serialize_content(QXmlStreamWriter& xmlWriter) const;
     
         /**
          * Deserializion of a  dense vectorfield from a QIODevice.
@@ -600,7 +600,7 @@ class GRAIPE_VECTORFIELDS_EXPORT DenseWeightedVectorfield2D : public DenseVector
          *
          * \param out The output device for serialization.
          */
-		void serialize_content(QIODevice& out) const;
+		void serialize_content(QXmlStreamWriter& xmlWriter) const;
     
         /**
          * Deserializion of a  dense vectorfield from a QIODevice.

--- a/src/modules/vectorfields/densevectorfield.hxx
+++ b/src/modules/vectorfields/densevectorfield.hxx
@@ -407,7 +407,7 @@ class GRAIPE_VECTORFIELDS_EXPORT DenseVectorfield2D
         void setV(const ArrayViewType& new_v);
     
         /**
-         * Serialize the complete content of the dense vectorfield to a QIODevice.
+         * Serialize the complete content of the dense vectorfield to an xml file.
          * The serialization is just a binary stream of m_u followed by m_v.
          *
          * \param out The output device for serialization.
@@ -415,11 +415,11 @@ class GRAIPE_VECTORFIELDS_EXPORT DenseVectorfield2D
 		void serialize_content(QXmlStreamWriter& xmlWriter) const;
     
         /**
-         * Deserializion of a  dense vectorfield from a QIODevice.
+         * Deserialization of a  dense vectorfield from an xml file.
          * Since the serialization is just a binary stream of m_u and m_v
          * and we already know the size, it is quite easy the deserialize.
          *
-         * \param in The QIODevice, where we will read from.
+         * \param xmlReader The QXmlStreamReader, where we will read from.
          * \return True, if the content could be deserialized and the model is not locked.
          */
 		bool deserialize_content(QXmlStreamReader& xmlReader);
@@ -595,7 +595,7 @@ class GRAIPE_VECTORFIELDS_EXPORT DenseWeightedVectorfield2D : public DenseVector
 		virtual void setWeight(unsigned int x, unsigned int y, float new_w);
 		
         /**
-         * Serialize the complete content of the dense weighted vectorfield to a QIODevice.
+         * Serialize the complete content of the dense weighted vectorfield to an xml file.
          * The serialization is just a binary stream of m_u followed by m_v and m_w.
          *
          * \param out The output device for serialization.
@@ -603,11 +603,11 @@ class GRAIPE_VECTORFIELDS_EXPORT DenseWeightedVectorfield2D : public DenseVector
 		void serialize_content(QXmlStreamWriter& xmlWriter) const;
     
         /**
-         * Deserializion of a  dense vectorfield from a QIODevice.
+         * Deserialization of a  dense vectorfield from an xml file.
          * Since the serialization is just a binary stream of m_u, m_v and m_w
          * and we already know the size, it is quite easy the deserialize.
          *
-         * \param in The QIODevice, where we will read from.
+         * \param xmlReader The QXmlStreamReader, where we will read from.
          * \return True, if the content could be deserialized and the model is not locked.
          */
 		bool deserialize_content(QXmlStreamReader& xmlReader);

--- a/src/modules/vectorfields/densevectorfield.hxx
+++ b/src/modules/vectorfields/densevectorfield.hxx
@@ -422,7 +422,7 @@ class GRAIPE_VECTORFIELDS_EXPORT DenseVectorfield2D
          * \param in The QIODevice, where we will read from.
          * \return True, if the content could be deserialized and the model is not locked.
          */
-		bool deserialize_content(QIODevice& in);
+		bool deserialize_content(QXmlStreamReader& xmlReader);
     
     protected slots:
         /**
@@ -610,7 +610,7 @@ class GRAIPE_VECTORFIELDS_EXPORT DenseWeightedVectorfield2D : public DenseVector
          * \param in The QIODevice, where we will read from.
          * \return True, if the content could be deserialized and the model is not locked.
          */
-		bool deserialize_content(QIODevice& in);
+		bool deserialize_content(QXmlStreamReader& xmlReader);
 		
         /**
          * Constant reading access to the weights of each direction

--- a/src/modules/vectorfields/densevectorfield.hxx
+++ b/src/modules/vectorfields/densevectorfield.hxx
@@ -100,7 +100,7 @@ class GRAIPE_VECTORFIELDS_EXPORT DenseVectorfield2D
          *
          * \return Always "DenseVectorfield2D"
          */
-		QString typeName() const;
+		static QString typeName();
 		
         /**
          * The size of this vectorfield. 
@@ -529,7 +529,7 @@ class GRAIPE_VECTORFIELDS_EXPORT DenseWeightedVectorfield2D : public DenseVector
          *
          * \return Always "DenseWeightedVectorfield2D"
          */
-		QString typeName() const;
+		static QString typeName();
         
         /**
          * This does not remove all the vectors, but resets their directions 

--- a/src/modules/vectorfields/densevectorfieldimpex.cxx
+++ b/src/modules/vectorfields/densevectorfieldimpex.cxx
@@ -266,7 +266,7 @@ void DenseVectorfieldImporter::run()
  */
 DenseVectorfieldExporter::DenseVectorfieldExporter()
 {
-    m_parameters->addParameter("vectorfield", new ModelParameter("Vectorfield",	NULL,  "DenseVectorfield2D, DenseWeightedVectorfield2D"));
+    m_parameters->addParameter("vectorfield", new ModelParameter("Vectorfield",	"DenseVectorfield2D, DenseWeightedVectorfield2D"));
     m_parameters->addParameter("filename", new FilenameParameter(".flo filename", "", NULL));
 }
 

--- a/src/modules/vectorfields/densevectorfieldimpex.cxx
+++ b/src/modules/vectorfields/densevectorfieldimpex.cxx
@@ -246,18 +246,15 @@ void DenseVectorfieldImporter::run()
         else 
         {
             emit errorMessage(QString("Explainable error occured: Dense vectorfield could not be imported"));
-            m_results.clear();
         }
     }
     catch(std::exception& e)
     {
         emit errorMessage(QString("Explainable error occured: ") + QString::fromStdString(e.what()));
-        m_results.clear();
     }
     catch(...)
     {
-        emit errorMessage(QString("Non-explainable error occured"));		
-        m_results.clear();
+        emit errorMessage(QString("Non-explainable error occured"));
     }
 }
 

--- a/src/modules/vectorfields/densevectorfieldviewcontroller.cxx
+++ b/src/modules/vectorfields/densevectorfieldviewcontroller.cxx
@@ -243,7 +243,7 @@ QRectF DenseVectorfield2DViewController::boundingRect() const
  *
  * \return Always: "DenseVectorfield2DViewController"
  */
-QString DenseVectorfield2DViewController::typeName() const
+QString DenseVectorfield2DViewController::typeName()
 { 
 	return "DenseVectorfield2DViewController"; 
 }
@@ -565,7 +565,7 @@ QRectF DenseVectorfield2DParticleViewController::boundingRect() const
  *
  * \return Always: "DenseVectorfield2DParticleViewController"
  */
-QString DenseVectorfield2DParticleViewController::typeName() const
+QString DenseVectorfield2DParticleViewController::typeName()
 { 
 	return "DenseVectorfield2DParticleView"; 
 }
@@ -925,7 +925,7 @@ void DenseWeightedVectorfield2DViewController::paint(QPainter *painter, const QS
  *
  * \return Always: "DenseWeightedVectorfield2DViewController"
  */
-QString DenseWeightedVectorfield2DViewController::typeName() const
+QString DenseWeightedVectorfield2DViewController::typeName()
 { 
 	return "DenseWeightedVectorfield2DViewController"; 
 }
@@ -1210,7 +1210,7 @@ void DenseWeightedVectorfield2DParticleViewController::paint(QPainter *painter, 
  *
  * \return Always: "DenseWeightedVectorfield2DParticleViewController"
  */
-QString DenseWeightedVectorfield2DParticleViewController::typeName() const
+QString DenseWeightedVectorfield2DParticleViewController::typeName()
 { 
 	return "DenseWeightedVectorfield2DParticleView"; 
 }

--- a/src/modules/vectorfields/densevectorfieldviewcontroller.cxx
+++ b/src/modules/vectorfields/densevectorfieldviewcontroller.cxx
@@ -243,7 +243,7 @@ QRectF DenseVectorfield2DViewController::boundingRect() const
  *
  * \return Always: "DenseVectorfield2DViewController"
  */
-QString DenseVectorfield2DViewController::typeName()
+QString DenseVectorfield2DViewController::typeName() const
 { 
 	return "DenseVectorfield2DViewController"; 
 }
@@ -565,7 +565,7 @@ QRectF DenseVectorfield2DParticleViewController::boundingRect() const
  *
  * \return Always: "DenseVectorfield2DParticleViewController"
  */
-QString DenseVectorfield2DParticleViewController::typeName()
+QString DenseVectorfield2DParticleViewController::typeName() const
 { 
 	return "DenseVectorfield2DParticleView"; 
 }
@@ -925,7 +925,7 @@ void DenseWeightedVectorfield2DViewController::paint(QPainter *painter, const QS
  *
  * \return Always: "DenseWeightedVectorfield2DViewController"
  */
-QString DenseWeightedVectorfield2DViewController::typeName()
+QString DenseWeightedVectorfield2DViewController::typeName() const
 { 
 	return "DenseWeightedVectorfield2DViewController"; 
 }
@@ -1210,7 +1210,7 @@ void DenseWeightedVectorfield2DParticleViewController::paint(QPainter *painter, 
  *
  * \return Always: "DenseWeightedVectorfield2DParticleViewController"
  */
-QString DenseWeightedVectorfield2DParticleViewController::typeName()
+QString DenseWeightedVectorfield2DParticleViewController::typeName() const
 { 
 	return "DenseWeightedVectorfield2DParticleView"; 
 }

--- a/src/modules/vectorfields/densevectorfieldviewcontroller.hxx
+++ b/src/modules/vectorfields/densevectorfieldviewcontroller.hxx
@@ -91,7 +91,7 @@ class GRAIPE_VECTORFIELDS_EXPORT DenseVectorfield2DViewController
          *
          * \return Always: "DenseVectorfield2DViewController"
          */
-		QString typeName() const;
+		static QString typeName();
     
         /**
          * Specialization of the update of  the parameters of this ViewController according to the current
@@ -191,7 +191,7 @@ class GRAIPE_VECTORFIELDS_EXPORT DenseVectorfield2DParticleViewController
          *
          * \return Always: "DenseVectorfield2DParticleViewController"
          */
-		QString typeName() const;
+		static QString typeName();
     
         /**
          * Specialization of the update of  the parameters of this ViewController according to the current
@@ -294,7 +294,7 @@ class GRAIPE_VECTORFIELDS_EXPORT DenseWeightedVectorfield2DViewController
          *
          * \return Always: "DenseWeightedVectorfield2DViewController"
          */
-		QString typeName() const;
+		static QString typeName();
 	
         /**
          * Specialization of the update of  the parameters of this ViewController according to the current
@@ -375,7 +375,7 @@ class GRAIPE_VECTORFIELDS_EXPORT DenseWeightedVectorfield2DParticleViewControlle
          *
          * \return Always: "DenseWeightedVectorfield2DParticleViewController"
          */
-		QString typeName() const;
+		static QString typeName();
     
         /**
          * Specialization of the update of  the parameters of this ViewController according to the current

--- a/src/modules/vectorfields/densevectorfieldviewcontroller.hxx
+++ b/src/modules/vectorfields/densevectorfieldviewcontroller.hxx
@@ -91,7 +91,7 @@ class GRAIPE_VECTORFIELDS_EXPORT DenseVectorfield2DViewController
          *
          * \return Always: "DenseVectorfield2DViewController"
          */
-		static QString typeName();
+		virtual QString typeName() const;
     
         /**
          * Specialization of the update of  the parameters of this ViewController according to the current
@@ -191,7 +191,7 @@ class GRAIPE_VECTORFIELDS_EXPORT DenseVectorfield2DParticleViewController
          *
          * \return Always: "DenseVectorfield2DParticleViewController"
          */
-		static QString typeName();
+		virtual QString typeName() const;
     
         /**
          * Specialization of the update of  the parameters of this ViewController according to the current
@@ -294,7 +294,7 @@ class GRAIPE_VECTORFIELDS_EXPORT DenseWeightedVectorfield2DViewController
          *
          * \return Always: "DenseWeightedVectorfield2DViewController"
          */
-		static QString typeName();
+		virtual QString typeName() const;
 	
         /**
          * Specialization of the update of  the parameters of this ViewController according to the current
@@ -375,7 +375,7 @@ class GRAIPE_VECTORFIELDS_EXPORT DenseWeightedVectorfield2DParticleViewControlle
          *
          * \return Always: "DenseWeightedVectorfield2DParticleViewController"
          */
-		static QString typeName();
+		virtual QString typeName() const;
     
         /**
          * Specialization of the update of  the parameters of this ViewController according to the current

--- a/src/modules/vectorfields/sparsevectorfield.cxx
+++ b/src/modules/vectorfields/sparsevectorfield.cxx
@@ -259,14 +259,15 @@ bool SparseVectorfield2D::deserialize_item(const QString & serial)
  *
  * \param out The output device for serialization.
  */
-void SparseVectorfield2D::serialize_content(QIODevice& out) const
+void SparseVectorfield2D::serialize_content(QXmlStreamWriter& xmlWriter) const
 {
-     write_on_device(item_header(), out);
-    
+//TODO!!!     write_on_device(item_header(), out);
+    /*
 	for(unsigned int i=0; i < size(); ++i)
     {
 		write_on_device("\n" + serialize_item(i), out);
 	}
+    */
 }
 
 /**

--- a/src/modules/vectorfields/sparsevectorfield.cxx
+++ b/src/modules/vectorfields/sparsevectorfield.cxx
@@ -261,13 +261,15 @@ bool SparseVectorfield2D::deserialize_item(const QString & serial)
  */
 void SparseVectorfield2D::serialize_content(QXmlStreamWriter& xmlWriter) const
 {
-//TODO!!!     write_on_device(item_header(), out);
-    /*
+    xmlWriter.writeTextElement("Legend", item_header());
+    
 	for(unsigned int i=0; i < size(); ++i)
     {
-		write_on_device("\n" + serialize_item(i), out);
-	}
-    */
+        xmlWriter.writeStartElement("Vector");
+        xmlWriter.writeAttribute("ID", QString::number(i));
+            xmlWriter.writeCharacters(serialize_item(i));
+        xmlWriter.writeEndElement();
+    }
 }
 
 /**
@@ -281,36 +283,27 @@ void SparseVectorfield2D::serialize_content(QXmlStreamWriter& xmlWriter) const
  */
 bool SparseVectorfield2D::deserialize_content(QXmlStreamReader& xmlReader)
 {
-//TODO!!!
-/**    if(locked())
+    if (locked())
         return false;
-        
-    //Read in header line and then throw it away immideately
-    if(!in.atEnd())
-        in.readLine();
-    
+
     //Clean up
 	clear();
     updateModel();
-			
+    
     //Read the entries
-    while(!in.atEnd())
+    while(xmlReader.readNextStartElement())
     {
-        QString line = QString(in.readLine());
-        
-        //ignore comments and empty lines
-        if(!line.isEmpty() && !line.startsWith(";"))
+        if(xmlReader.name() == "Vector")
         {
-            if (!deserialize_item(line))
-            {
-                qCritical() << "Vectorfield2D::deserialize_content: Vector could not be deserialized from: '" << line << "'";
+            if(!deserialize_item(xmlReader.readElementText()))
                 return false;
-            }
+        }
+        else
+        {
+            xmlReader.skipCurrentElement();
         }
     }
     return true;
-    */
-    return false;
 }
 
 

--- a/src/modules/vectorfields/sparsevectorfield.cxx
+++ b/src/modules/vectorfields/sparsevectorfield.cxx
@@ -279,9 +279,10 @@ void SparseVectorfield2D::serialize_content(QXmlStreamWriter& xmlWriter) const
  * \param in The QIODevice, where we will read from.
  * \return True, if the content could be deserialized and the model is not locked.
  */
-bool SparseVectorfield2D::deserialize_content(QIODevice& in)
+bool SparseVectorfield2D::deserialize_content(QXmlStreamReader& xmlReader)
 {
-    if(locked())
+//TODO!!!
+/**    if(locked())
         return false;
         
     //Read in header line and then throw it away immideately
@@ -308,6 +309,8 @@ bool SparseVectorfield2D::deserialize_content(QIODevice& in)
         }
     }
     return true;
+    */
+    return false;
 }
 
 

--- a/src/modules/vectorfields/sparsevectorfield.cxx
+++ b/src/modules/vectorfields/sparsevectorfield.cxx
@@ -232,7 +232,7 @@ bool SparseVectorfield2D::deserialize_item(const QString & serial)
         return false;
         
 	//try to split content into data entries
-	QStringList values = split_string(serial, ", "); 
+	QStringList values = serial.split(", ");
 	if(values.size() >= 4)
 	{
 		try
@@ -251,7 +251,7 @@ bool SparseVectorfield2D::deserialize_item(const QString & serial)
 }
 
 /**
- * Serialize the complete content of the sparse vectorfield to a QIODevice.
+ * Serialize the complete content of the sparse vectorfield to an xml file.
  * Mainly prints:
  *   item_header()
  * and for each vector:
@@ -273,12 +273,12 @@ void SparseVectorfield2D::serialize_content(QXmlStreamWriter& xmlWriter) const
 }
 
 /**
- * Deserializion of a  sparse vectorfield from a QIODevice.
+ * Deserialization of a  sparse vectorfield from an xml file.
  * The first line is the header as given in item_header(), which is ignored however.
  * Each following line has to be one valid vector serialization.
  * Does nothing if the model is locked.
  *
- * \param in The QIODevice, where we will read from.
+ * \param xmlReader The QXmlStreamReader, where we will read from.
  * \return True, if the content could be deserialized and the model is not locked.
  */
 bool SparseVectorfield2D::deserialize_content(QXmlStreamReader& xmlReader)
@@ -479,7 +479,7 @@ bool SparseWeightedVectorfield2D::deserialize_item(const QString & serial)
         return false;
     
 	//try to split content into data entries
-	QStringList values = split_string(serial, ", "); 
+	QStringList values = serial.split(", ");
 	if(values.size() >= 5)
 	{
 		try
@@ -861,7 +861,7 @@ QString SparseMultiVectorfield2D::serialize_item(unsigned int index) const
 bool SparseMultiVectorfield2D::deserialize_item(const QString & serial)
 {
     //try to split content into data entries
-	QStringList values = split_string(serial , ", "); 
+	QStringList values = serial.split(", ");
 	if(values.size() >= 4)
 	{
 		try
@@ -1227,7 +1227,7 @@ QString SparseWeightedMultiVectorfield2D::serialize_item(unsigned int index) con
 bool SparseWeightedMultiVectorfield2D::deserialize_item(const QString & serial)
 {
     //try to split content into data entries
-	QStringList values = split_string(serial , ", "); 
+	QStringList values = serial.split(", ");
 	if(values.size() >= 5)
 	{
 		try

--- a/src/modules/vectorfields/sparsevectorfield.cxx
+++ b/src/modules/vectorfields/sparsevectorfield.cxx
@@ -66,7 +66,7 @@ SparseVectorfield2D::SparseVectorfield2D(const SparseVectorfield2D & vf)
  *
  * \return Always "SparseVectorfield2D"
  */
-QString SparseVectorfield2D::typeName()
+QString SparseVectorfield2D::typeName() const
 { 
 	return QString("SparseVectorfield2D");
 }
@@ -351,7 +351,7 @@ SparseWeightedVectorfield2D::SparseWeightedVectorfield2D(const SparseWeightedVec
  *
  * \return Always "SparseWeightedVectorfield2D"
  */
-QString SparseWeightedVectorfield2D::typeName()
+QString SparseWeightedVectorfield2D::typeName() const
 { 
 	return QString("SparseWeightedVectorfield2D");
 }
@@ -554,7 +554,7 @@ SparseMultiVectorfield2D::SparseMultiVectorfield2D(const SparseMultiVectorfield2
  *
  * \return Always "SparseMultiVectorfield2D"
  */
-QString SparseMultiVectorfield2D::typeName()
+QString SparseMultiVectorfield2D::typeName() const
 { 
 	return	QString("SparseMultiVectorfield2D");
 }
@@ -933,7 +933,7 @@ SparseWeightedMultiVectorfield2D::SparseWeightedMultiVectorfield2D()
 {
 }
 
-QString SparseWeightedMultiVectorfield2D::typeName()
+QString SparseWeightedMultiVectorfield2D::typeName() const
 {
 	return	QString("SparseWeightedMultiVectorfield2D");
 }

--- a/src/modules/vectorfields/sparsevectorfield.cxx
+++ b/src/modules/vectorfields/sparsevectorfield.cxx
@@ -66,7 +66,7 @@ SparseVectorfield2D::SparseVectorfield2D(const SparseVectorfield2D & vf)
  *
  * \return Always "SparseVectorfield2D"
  */
-QString SparseVectorfield2D::typeName() const
+QString SparseVectorfield2D::typeName()
 { 
 	return QString("SparseVectorfield2D");
 }
@@ -199,7 +199,7 @@ void SparseVectorfield2D::removeVector(unsigned int index)
  * 
  * \return Always: "pos_x, pos_y, dir_x, dir_y".
  */
-QString SparseVectorfield2D::item_header() const
+QString SparseVectorfield2D::csvHeader() const
 {
 	return "pos_x, pos_y, dir_x, dir_y";
 }
@@ -253,7 +253,7 @@ bool SparseVectorfield2D::deserialize_item(const QString & serial)
 /**
  * Serialize the complete content of the sparse vectorfield to an xml file.
  * Mainly prints:
- *   item_header()
+ *   csvHeader
  * and for each vector:
  *   newline + serialize_item().
  *
@@ -261,7 +261,7 @@ bool SparseVectorfield2D::deserialize_item(const QString & serial)
  */
 void SparseVectorfield2D::serialize_content(QXmlStreamWriter& xmlWriter) const
 {
-    xmlWriter.writeTextElement("Legend", item_header());
+    xmlWriter.writeTextElement("Legend", csvHeader());
     
 	for(unsigned int i=0; i < size(); ++i)
     {
@@ -274,7 +274,7 @@ void SparseVectorfield2D::serialize_content(QXmlStreamWriter& xmlWriter) const
 
 /**
  * Deserialization of a  sparse vectorfield from an xml file.
- * The first line is the header as given in item_header(), which is ignored however.
+ * The first line is the header as given in csvHeader, which is ignored however.
  * Each following line has to be one valid vector serialization.
  * Does nothing if the model is locked.
  *
@@ -351,7 +351,7 @@ SparseWeightedVectorfield2D::SparseWeightedVectorfield2D(const SparseWeightedVec
  *
  * \return Always "SparseWeightedVectorfield2D"
  */
-QString SparseWeightedVectorfield2D::typeName() const
+QString SparseWeightedVectorfield2D::typeName()
 { 
 	return QString("SparseWeightedVectorfield2D");
 }
@@ -448,9 +448,9 @@ void SparseWeightedVectorfield2D::removeVector(unsigned int index)
  * 
  * \return Always: "pos_x, pos_y, dir_x, dir_y, weight".
  */
-QString SparseWeightedVectorfield2D::item_header() const
+QString SparseWeightedVectorfield2D::csvHeader() const
 {
-	return SparseVectorfield2D::item_header() + ", weight";
+	return SparseVectorfield2D::csvHeader() + ", weight";
 }
 
 /**
@@ -554,7 +554,7 @@ SparseMultiVectorfield2D::SparseMultiVectorfield2D(const SparseMultiVectorfield2
  *
  * \return Always "SparseMultiVectorfield2D"
  */
-QString SparseMultiVectorfield2D::typeName() const
+QString SparseMultiVectorfield2D::typeName()
 { 
 	return	QString("SparseMultiVectorfield2D");
 }
@@ -820,9 +820,9 @@ void SparseMultiVectorfield2D::removeVector(unsigned int index)
  * 
  * \return Always: "pos_x, pos_y, dir_x, dir_y, alt0_dir_x, alt0_dir_y, ... , altN_dir_x, altN_dir_y".
  */
-QString SparseMultiVectorfield2D::item_header() const
+QString SparseMultiVectorfield2D::csvHeader() const
 {
-    QString result =  SparseVectorfield2D::item_header();
+    QString result =  SparseVectorfield2D::csvHeader();
 	
 	for( unsigned int i = 0; i<alternatives(); ++i)
 	{
@@ -933,7 +933,7 @@ SparseWeightedMultiVectorfield2D::SparseWeightedMultiVectorfield2D()
 {
 }
 
-QString SparseWeightedMultiVectorfield2D::typeName() const
+QString SparseWeightedMultiVectorfield2D::typeName()
 {
 	return	QString("SparseWeightedMultiVectorfield2D");
 }
@@ -1185,9 +1185,9 @@ void SparseWeightedMultiVectorfield2D::removeVector(unsigned int index)
  * 
  * \return Always: "pos_x, pos_y, dir_x, dir_y, weight, alt0_dir_x, alt0_dir_y, alt0_weight, ... , altN_dir_x, altN_dir_y, altN_weight".
  */
-QString SparseWeightedMultiVectorfield2D::item_header() const
+QString SparseWeightedMultiVectorfield2D::csvHeader() const
 {
-    QString result =  SparseVectorfield2D::item_header() + ", weight";
+    QString result =  SparseVectorfield2D::csvHeader() + ", weight";
 	
 	for( unsigned int i = 0; i<alternatives(); ++i)
 	{

--- a/src/modules/vectorfields/sparsevectorfield.cxx
+++ b/src/modules/vectorfields/sparsevectorfield.cxx
@@ -211,7 +211,7 @@ QString SparseVectorfield2D::csvHeader() const
  * \param index Index of the vector to be serialized.
  * \return QString of the vector, namely "pos_x, pos_y, dir_x, dir_y".
  */
-QString SparseVectorfield2D::serialize_item(unsigned int index) const
+QString SparseVectorfield2D::itemToCSV(unsigned int index) const
 {
 	return   QString::number(m_origins[index].x(), 'g', 10)    + ", "
            + QString::number(m_origins[index].y(), 'g', 10)    + ", "
@@ -226,7 +226,7 @@ QString SparseVectorfield2D::serialize_item(unsigned int index) const
  * \return True, if the item could be deserialized and the model is not locked.
  *         The serialization is ordered as: pos_x, pos_y, dir_x, dir_y
  */
-bool SparseVectorfield2D::deserialize_item(const QString & serial)
+bool SparseVectorfield2D::itemFromCSV(const QString & serial)
 {
     if(locked())
         return false;
@@ -251,6 +251,37 @@ bool SparseVectorfield2D::deserialize_item(const QString & serial)
 }
 
 /**
+ * Serialization of a single vector inside the list at a given index.
+ * The vector will be serialized by means of comma separated values.
+ * 
+ * \param index Index of the vector to be serialized.
+ * \return QString of the vector, namely "pos_x, pos_y, dir_x, dir_y".
+ */
+void SparseVectorfield2D::serialize_item(unsigned int index, QXmlStreamWriter& xmlWriter) const
+{
+    xmlWriter.writeTextElement("x", QString::number(m_origins[index].x(), 'g', 10));
+    xmlWriter.writeTextElement("y",  QString::number(m_origins[index].y(), 'g', 10));
+    xmlWriter.writeTextElement("u", QString::number(m_directions[index].x(), 'g', 10));
+    xmlWriter.writeTextElement("v", QString::number(m_directions[index].y(), 'g', 10));
+}
+
+/**
+ * Deserialization/addition of a vector from a string to this list.
+ *
+ * \param serial A QString containing the serialization of the vector.
+ * \return True, if the item could be deserialized and the model is not locked.
+ *         The serialization is ordered as: pos_x, pos_y, dir_x, dir_y
+ */
+bool SparseVectorfield2D::deserialize_item(QXmlStreamReader& xmlReader)
+{
+    if(locked())
+        return false;
+    
+    //TODO
+    return false;
+}
+
+/**
  * Serialize the complete content of the sparse vectorfield to an xml file.
  * Mainly prints:
  *   csvHeader
@@ -261,13 +292,11 @@ bool SparseVectorfield2D::deserialize_item(const QString & serial)
  */
 void SparseVectorfield2D::serialize_content(QXmlStreamWriter& xmlWriter) const
 {
-    xmlWriter.writeTextElement("Legend", csvHeader());
-    
 	for(unsigned int i=0; i < size(); ++i)
     {
-        xmlWriter.writeStartElement("Vector");
+        xmlWriter.writeStartElement("Vector2D");
         xmlWriter.writeAttribute("ID", QString::number(i));
-            xmlWriter.writeCharacters(serialize_item(i));
+            serialize_item(i, xmlWriter);
         xmlWriter.writeEndElement();
     }
 }
@@ -293,9 +322,9 @@ bool SparseVectorfield2D::deserialize_content(QXmlStreamReader& xmlReader)
     //Read the entries
     while(xmlReader.readNextStartElement())
     {
-        if(xmlReader.name() == "Vector")
+        if(xmlReader.name() == "Vector2D")
         {
-            if(!deserialize_item(xmlReader.readElementText()))
+            if(!deserialize_item(xmlReader))
                 return false;
         }
         else
@@ -460,9 +489,9 @@ QString SparseWeightedVectorfield2D::csvHeader() const
  * \param index Index of the vector to be serialized.
  * \return QString of the vector, namely "pos_x, pos_y, dir_x, dir_y, weight".
  */
-QString SparseWeightedVectorfield2D::serialize_item(unsigned int index) const
+QString SparseWeightedVectorfield2D::itemToCSV(unsigned int index) const
 {
-	return SparseVectorfield2D::serialize_item(index) + ", "
+	return SparseVectorfield2D::itemToCSV(index) + ", "
            + QString::number(m_weights[index], 'g', 10);
 }
 
@@ -473,7 +502,7 @@ QString SparseWeightedVectorfield2D::serialize_item(unsigned int index) const
  * \return True, if the item could be deserialized and the model is not locked.
  *         The serialization is ordered as: pos_x, pos_y, dir_x, dir_y, weight
  */
-bool SparseWeightedVectorfield2D::deserialize_item(const QString & serial)
+bool SparseWeightedVectorfield2D::itemFromCSV(const QString & serial)
 {
     if (locked())
         return false;
@@ -484,7 +513,7 @@ bool SparseWeightedVectorfield2D::deserialize_item(const QString & serial)
 	{
 		try
 		{
-			SparseVectorfield2D::deserialize_item(serial);
+			SparseVectorfield2D::itemFromCSV(serial);
 			m_weights.push_back(values[4].toFloat());
 			return true;
 		}
@@ -495,6 +524,33 @@ bool SparseWeightedVectorfield2D::deserialize_item(const QString & serial)
 		}
 	}
 	return false;
+}
+/**
+ * Serialization of a single weighted vector inside the list at a given index.
+ * The vector will be serialized by means of comma separated values.
+ * 
+ * \param index Index of the vector to be serialized.
+ * \return QString of the vector, namely "pos_x, pos_y, dir_x, dir_y, weight".
+ */
+void SparseWeightedVectorfield2D::serialize_item(unsigned int index, QXmlStreamWriter& xmlWriter) const
+{
+	//TODO
+}
+
+/**
+ * Deserialization/addition of a weihgted vector from a string to this list.
+ *
+ * \param serial A QString containing the serialization of the vector.
+ * \return True, if the item could be deserialized and the model is not locked.
+ *         The serialization is ordered as: pos_x, pos_y, dir_x, dir_y, weight
+ */
+bool SparseWeightedVectorfield2D::deserialize_item(QXmlStreamReader& xmlReader)
+{
+    if (locked())
+        return false;
+    
+	//TODO
+    return false;
 }
 
 
@@ -839,9 +895,9 @@ QString SparseMultiVectorfield2D::csvHeader() const
  * \param index Index of the vector to be serialized.
  * \return QString of the vector, namely "pos_x, pos_y, dir_x, dir_y, alt0_dir_x, alt0_dir_y, ... , altN_dir_x, altN_dir_y".
  */
-QString SparseMultiVectorfield2D::serialize_item(unsigned int index) const
+QString SparseMultiVectorfield2D::itemToCSV(unsigned int index) const
 {
-	QString result = SparseVectorfield2D::serialize_item(index);
+	QString result = SparseVectorfield2D::itemToCSV(index);
     
 	for( unsigned int i = 1; i<=alternatives(); ++i)
 	{
@@ -858,7 +914,7 @@ QString SparseMultiVectorfield2D::serialize_item(unsigned int index) const
  * \return True, if the item could be deserialized and the model is not locked.
  *         The serialization is ordered as: pos_x, pos_y, dir_x, dir_y, alt0_dir_x, alt0_dir_y, ... , altN_dir_x, altN_dir_y
  */
-bool SparseMultiVectorfield2D::deserialize_item(const QString & serial)
+bool SparseMultiVectorfield2D::itemFromCSV(const QString & serial)
 {
     //try to split content into data entries
 	QStringList values = serial.split(", ");
@@ -866,7 +922,7 @@ bool SparseMultiVectorfield2D::deserialize_item(const QString & serial)
 	{
 		try
 		{
-			if(SparseVectorfield2D::deserialize_item(serial))
+			if(SparseVectorfield2D::itemFromCSV(serial))
             {
                 //The parameters should have been deserialized before, so we can use the properties:
                 std::vector<PointType> alt_dirs(alternatives());
@@ -887,6 +943,34 @@ bool SparseMultiVectorfield2D::deserialize_item(const QString & serial)
 		}
 	}
 	return false;
+}
+
+/**
+ * Serialization of a single multi vector inside the list at a given index.
+ * The vector will be serialized by means of comma separated values.
+ * 
+ * \param index Index of the vector to be serialized.
+ * \return QString of the vector, namely "pos_x, pos_y, dir_x, dir_y, alt0_dir_x, alt0_dir_y, ... , altN_dir_x, altN_dir_y".
+ */
+void SparseMultiVectorfield2D::serialize_item(unsigned int index, QXmlStreamWriter& xmlWriter) const
+{
+	//TODO
+}
+
+/**
+ * Deserialization/addition of a multi vector from a string to this list.
+ *
+ * \param serial A QString containing the serialization of the vector.
+ * \return True, if the item could be deserialized and the model is not locked.
+ *         The serialization is ordered as: pos_x, pos_y, dir_x, dir_y, alt0_dir_x, alt0_dir_y, ... , altN_dir_x, altN_dir_y
+ */
+bool SparseMultiVectorfield2D::deserialize_item(QXmlStreamReader& xmlReader)
+{
+    if (locked())
+        return false;
+    
+	//TODO
+    return false;
 }
 
 /**
@@ -1204,9 +1288,9 @@ QString SparseWeightedMultiVectorfield2D::csvHeader() const
  * \param index Index of the vector to be serialized.
  * \return QString of the vector, namely "pos_x, pos_y, dir_x, dir_y, weight, alt0_dir_x, alt0_dir_y, alt0_weight, ... , altN_dir_x, altN_dir_y, altN_weight".
  */
-QString SparseWeightedMultiVectorfield2D::serialize_item(unsigned int index) const
+QString SparseWeightedMultiVectorfield2D::itemToCSV(unsigned int index) const
 {
-	QString result = SparseVectorfield2D::serialize_item(index) + ", " + QString::number(weight(index), 'g', 10);
+	QString result = SparseVectorfield2D::itemToCSV(index) + ", " + QString::number(weight(index), 'g', 10);
     
 	for( unsigned int i = 0; i<alternatives(); ++i)
 	{
@@ -1224,7 +1308,7 @@ QString SparseWeightedMultiVectorfield2D::serialize_item(unsigned int index) con
  * \return True, if the item could be deserialized and the model is not locked.
  *         The serialization is ordered as: "pos_x, pos_y, dir_x, dir_y, weight, alt0_dir_x, alt0_dir_y, alt0_weight, ... , altN_dir_x, altN_dir_y, altN_weight".
  */
-bool SparseWeightedMultiVectorfield2D::deserialize_item(const QString & serial)
+bool SparseWeightedMultiVectorfield2D::itemFromCSV(const QString & serial)
 {
     //try to split content into data entries
 	QStringList values = serial.split(", ");
@@ -1232,7 +1316,7 @@ bool SparseWeightedMultiVectorfield2D::deserialize_item(const QString & serial)
 	{
 		try
 		{
-			if(SparseVectorfield2D::deserialize_item(serial))
+			if(SparseVectorfield2D::itemFromCSV(serial))
             {
                 m_weights.push_back(values[4].toFloat());
                 
@@ -1261,6 +1345,33 @@ bool SparseWeightedMultiVectorfield2D::deserialize_item(const QString & serial)
 	return false;
 }
 
+/**
+ * Serialization of a single weighted multi vector inside the list at a given index.
+ * The vector will be serialized by means of comma separated values.
+ * 
+ * \param index Index of the vector to be serialized.
+ * \return QString of the vector, namely "pos_x, pos_y, dir_x, dir_y, weight, alt0_dir_x, alt0_dir_y, alt0_weight, ... , altN_dir_x, altN_dir_y, altN_weight".
+ */
+void SparseWeightedMultiVectorfield2D::serialize_item(unsigned int index, QXmlStreamWriter& xmlWriter) const
+{
+	//TODO
+}
+
+/**
+ * Deserialization/addition of a weighted multi vector from a string to this list.
+ *
+ * \param serial A QString containing the serialization of the vector.
+ * \return True, if the item could be deserialized and the model is not locked.
+ *         The serialization is ordered as: "pos_x, pos_y, dir_x, dir_y, weight, alt0_dir_x, alt0_dir_y, alt0_weight, ... , altN_dir_x, altN_dir_y, altN_weight".
+ */
+bool SparseWeightedMultiVectorfield2D::deserialize_item(QXmlStreamReader& xmlReader)
+{
+    if (locked())
+        return false;
+    
+	//TODO
+    return false;
+}
 /**
  * This slot is called, whenever some parameter is changed.
  * It rearranges the size of the weight alternatives' vector.

--- a/src/modules/vectorfields/sparsevectorfield.hxx
+++ b/src/modules/vectorfields/sparsevectorfield.hxx
@@ -168,7 +168,7 @@ class GRAIPE_VECTORFIELDS_EXPORT SparseVectorfield2D
 		virtual bool deserialize_item(const QString& serial);
     
         /**
-         * Serialize the complete content of the sparse vectorfield to a QIODevice.
+         * Serialize the complete content of the sparse vectorfield to an xml file.
          * Mainly prints:
          *   item_header()
          * and for each vector:
@@ -179,11 +179,11 @@ class GRAIPE_VECTORFIELDS_EXPORT SparseVectorfield2D
 		void serialize_content(QXmlStreamWriter& xmlWriter) const;
     
         /**
-         * Deserializion of a  sparse vectorfield from a QIODevice.
+         * Deserialization of a  sparse vectorfield from an xml file.
          * The first line is the header as given in item_header(), which is ignored however.
          * Each following line has to be one valid vector serialization.
          *
-         * \param in The QIODevice, where we will read from.
+         * \param xmlReader The QXmlStreamReader, where we will read from.
          * \return True, if the content could be deserialized and the model is not locked.
          */
 		bool deserialize_content(QXmlStreamReader& xmlReader);

--- a/src/modules/vectorfields/sparsevectorfield.hxx
+++ b/src/modules/vectorfields/sparsevectorfield.hxx
@@ -69,7 +69,7 @@ class GRAIPE_VECTORFIELDS_EXPORT SparseVectorfield2D
          *
          * \return Always "SparseVectorfield2D"
          */
-		static QString typeName();
+		virtual QString typeName() const;
     
         /**
          * The size of this vectorfield. 
@@ -218,7 +218,7 @@ class GRAIPE_VECTORFIELDS_EXPORT SparseWeightedVectorfield2D : public SparseVect
          *
          * \return Always "SparseWeightedVectorfield2D"
          */
-		static QString typeName();
+		virtual QString typeName() const;
     
         /**
          * The removal of all vectors of this vectorfield.
@@ -329,7 +329,7 @@ class GRAIPE_VECTORFIELDS_EXPORT SparseMultiVectorfield2D
          *
          * \return Always "SparseMultiVectorfield2D"
          */
-		static QString typeName();
+		virtual QString typeName() const;
     
         /**
          * The removal of all vectors of this vectorfield.
@@ -564,7 +564,7 @@ class GRAIPE_VECTORFIELDS_EXPORT SparseWeightedMultiVectorfield2D : public Spars
 		SparseWeightedMultiVectorfield2D(const SparseWeightedMultiVectorfield2D & vf);	
 		SparseWeightedMultiVectorfield2D();
 		
-		static QString typeName();
+		virtual QString typeName() const;
 		
         /**
          * The removal of all vectors of this vectorfield.

--- a/src/modules/vectorfields/sparsevectorfield.hxx
+++ b/src/modules/vectorfields/sparsevectorfield.hxx
@@ -186,7 +186,7 @@ class GRAIPE_VECTORFIELDS_EXPORT SparseVectorfield2D
          * \param in The QIODevice, where we will read from.
          * \return True, if the content could be deserialized and the model is not locked.
          */
-		bool deserialize_content(QIODevice& in);
+		bool deserialize_content(QXmlStreamReader& xmlReader);
 		
 	protected:
         //Data containers for the origins and directions

--- a/src/modules/vectorfields/sparsevectorfield.hxx
+++ b/src/modules/vectorfields/sparsevectorfield.hxx
@@ -69,7 +69,7 @@ class GRAIPE_VECTORFIELDS_EXPORT SparseVectorfield2D
          *
          * \return Always "SparseVectorfield2D"
          */
-		QString typeName() const;
+		static QString typeName();
     
         /**
          * The size of this vectorfield. 
@@ -147,7 +147,7 @@ class GRAIPE_VECTORFIELDS_EXPORT SparseVectorfield2D
          * 
          * \return Always: "pos_x, pos_y, dir_x, dir_y".
          */
-		virtual QString item_header() const;
+		virtual QString csvHeader() const;
         
         /**
          * Serialization of a single vector inside the list at a given index.
@@ -170,7 +170,7 @@ class GRAIPE_VECTORFIELDS_EXPORT SparseVectorfield2D
         /**
          * Serialize the complete content of the sparse vectorfield to an xml file.
          * Mainly prints:
-         *   item_header()
+         *   csvHeader
          * and for each vector:
          *   newline + serialize_item().
          *
@@ -180,7 +180,7 @@ class GRAIPE_VECTORFIELDS_EXPORT SparseVectorfield2D
     
         /**
          * Deserialization of a  sparse vectorfield from an xml file.
-         * The first line is the header as given in item_header(), which is ignored however.
+         * The first line is the header as given in csvHeader, which is ignored however.
          * Each following line has to be one valid vector serialization.
          *
          * \param xmlReader The QXmlStreamReader, where we will read from.
@@ -218,7 +218,7 @@ class GRAIPE_VECTORFIELDS_EXPORT SparseWeightedVectorfield2D : public SparseVect
          *
          * \return Always "SparseWeightedVectorfield2D"
          */
-		QString typeName() const;
+		static QString typeName();
     
         /**
          * The removal of all vectors of this vectorfield.
@@ -277,7 +277,7 @@ class GRAIPE_VECTORFIELDS_EXPORT SparseWeightedVectorfield2D : public SparseVect
          * 
          * \return Always: "pos_x, pos_y, dir_x, dir_y, weight".
          */
-		virtual QString item_header() const;
+		virtual QString csvHeader() const;
         
         /**
          * Serialization of a single weighted vector inside the list at a given index.
@@ -329,7 +329,7 @@ class GRAIPE_VECTORFIELDS_EXPORT SparseMultiVectorfield2D
          *
          * \return Always "SparseMultiVectorfield2D"
          */
-		QString typeName() const;
+		static QString typeName();
     
         /**
          * The removal of all vectors of this vectorfield.
@@ -522,7 +522,7 @@ class GRAIPE_VECTORFIELDS_EXPORT SparseMultiVectorfield2D
          * 
          * \return Always: "pos_x, pos_y, dir_x, dir_y, alt0_dir_x, alt0_dir_y, ... , altN_dir_x, altN_dir_y".
          */
-		QString item_header() const;
+		QString csvHeader() const;
         
         /**
          * Serialization of a single multi vector inside the list at a given index.
@@ -564,7 +564,7 @@ class GRAIPE_VECTORFIELDS_EXPORT SparseWeightedMultiVectorfield2D : public Spars
 		SparseWeightedMultiVectorfield2D(const SparseWeightedMultiVectorfield2D & vf);	
 		SparseWeightedMultiVectorfield2D();
 		
-		QString typeName() const;
+		static QString typeName();
 		
         /**
          * The removal of all vectors of this vectorfield.
@@ -716,7 +716,7 @@ class GRAIPE_VECTORFIELDS_EXPORT SparseWeightedMultiVectorfield2D : public Spars
          * 
          * \return Always: "pos_x, pos_y, dir_x, dir_y, weight, alt0_dir_x, alt0_dir_y, alt0_weight, ... , altN_dir_x, altN_dir_y, altN_weight".
          */
-		QString item_header() const;
+		QString csvHeader() const;
         
         /**
          * Serialization of a single weighted multi vector inside the list at a given index.

--- a/src/modules/vectorfields/sparsevectorfield.hxx
+++ b/src/modules/vectorfields/sparsevectorfield.hxx
@@ -156,7 +156,7 @@ class GRAIPE_VECTORFIELDS_EXPORT SparseVectorfield2D
          * \param index Index of the vector to be serialized.
          * \return QString of the vector, namely "pos_x, pos_y, dir_x, dir_y".
          */
-		virtual QString serialize_item(unsigned int index) const;
+		virtual QString itemToCSV(unsigned int index) const;
         
         /**
          * Deserialization/addition of a vector from a string to this list.
@@ -165,7 +165,25 @@ class GRAIPE_VECTORFIELDS_EXPORT SparseVectorfield2D
          * \return True, if the item could be deserialized and the model is not locked.
          *         The serialization is ordered as: pos_x, pos_y, dir_x, dir_y
          */
-		virtual bool deserialize_item(const QString& serial);
+		virtual bool itemFromCSV(const QString& serial);
+        
+        /**
+         * Serialization of a single vector inside the list at a given index.
+         * The vector will be serialized by means of comma separated values.
+         * 
+         * \param index Index of the vector to be serialized.
+         * \return QString of the vector, namely "pos_x, pos_y, dir_x, dir_y".
+         */
+		virtual void serialize_item(unsigned int index, QXmlStreamWriter& xmlWriter) const;
+        
+        /**
+         * Deserialization/addition of a vector from a string to this list.
+         *
+         * \param serial A QString containing the serialization of the vector.
+         * \return True, if the item could be deserialized and the model is not locked.
+         *         The serialization is ordered as: pos_x, pos_y, dir_x, dir_y
+         */
+		virtual bool deserialize_item(QXmlStreamReader& xmlReader);
     
         /**
          * Serialize the complete content of the sparse vectorfield to an xml file.
@@ -176,7 +194,7 @@ class GRAIPE_VECTORFIELDS_EXPORT SparseVectorfield2D
          *
          * \param out The output device for serialization.
          */
-		void serialize_content(QXmlStreamWriter& xmlWriter) const;
+		virtual void serialize_content(QXmlStreamWriter& xmlWriter) const;
     
         /**
          * Deserialization of a  sparse vectorfield from an xml file.
@@ -186,7 +204,7 @@ class GRAIPE_VECTORFIELDS_EXPORT SparseVectorfield2D
          * \param xmlReader The QXmlStreamReader, where we will read from.
          * \return True, if the content could be deserialized and the model is not locked.
          */
-		bool deserialize_content(QXmlStreamReader& xmlReader);
+		virtual bool deserialize_content(QXmlStreamReader& xmlReader);
 		
 	protected:
         //Data containers for the origins and directions
@@ -277,7 +295,7 @@ class GRAIPE_VECTORFIELDS_EXPORT SparseWeightedVectorfield2D : public SparseVect
          * 
          * \return Always: "pos_x, pos_y, dir_x, dir_y, weight".
          */
-		virtual QString csvHeader() const;
+		QString csvHeader() const;
         
         /**
          * Serialization of a single weighted vector inside the list at a given index.
@@ -286,7 +304,7 @@ class GRAIPE_VECTORFIELDS_EXPORT SparseWeightedVectorfield2D : public SparseVect
          * \param index Index of the vector to be serialized.
          * \return QString of the vector, namely "pos_x, pos_y, dir_x, dir_y, weight".
          */
-		virtual QString serialize_item(unsigned int index) const;
+		QString itemToCSV(unsigned int index) const;
         
         /**
          * Deserialization/addition of a weighted vector from a string to this list.
@@ -295,7 +313,25 @@ class GRAIPE_VECTORFIELDS_EXPORT SparseWeightedVectorfield2D : public SparseVect
          * \return True, if the item could be deserialized and the model is not locked.
          *         The serialization is ordered as: pos_x, pos_y, dir_x, dir_y, weight
          */
-		virtual bool deserialize_item(const QString& serial);
+		bool itemFromCSV(const QString& serial);
+        
+        /**
+         * Serialization of a single weighted vector inside the list at a given index.
+         * The vector will be serialized by means of comma separated values.
+         * 
+         * \param index Index of the vector to be serialized.
+         * \return QString of the vector, namely "pos_x, pos_y, dir_x, dir_y, weight".
+         */
+		void serialize_item(unsigned int index, QXmlStreamWriter& xmlWriter) const;
+        
+        /**
+         * Deserialization/addition of a weighted vector from a string to this list.
+         *
+         * \param serial A QString containing the serialization of the vector.
+         * \return True, if the item could be deserialized and the model is not locked.
+         *         The serialization is ordered as: pos_x, pos_y, dir_x, dir_y, weight
+         */
+		bool deserialize_item(QXmlStreamReader& xmlWriter);
 		
 	protected:
         //Storage of the weights
@@ -531,7 +567,7 @@ class GRAIPE_VECTORFIELDS_EXPORT SparseMultiVectorfield2D
          * \param index Index of the vector to be serialized.
          * \return QString of the vector, namely "pos_x, pos_y, dir_x, dir_y, alt0_dir_x, alt0_dir_y, ... , altN_dir_x, altN_dir_y".
          */
-		QString serialize_item(unsigned int index) const;
+		QString itemToCSV(unsigned int index) const;
         
         /**
          * Deserialization/addition of a multi vector from a string to this list.
@@ -540,7 +576,25 @@ class GRAIPE_VECTORFIELDS_EXPORT SparseMultiVectorfield2D
          * \return True, if the item could be deserialized and the model is not locked.
          *         The serialization is ordered as: pos_x, pos_y, dir_x, dir_y, alt0_dir_x, alt0_dir_y, ... , altN_dir_x, altN_dir_y
          */
-		bool deserialize_item(const QString& serial);
+		bool itemFromCSV(const QString& serial);
+    
+        /**
+         * Serialization of a single multi vector inside the list at a given index.
+         * The vector will be serialized by means of comma separated values.
+         * 
+         * \param index Index of the vector to be serialized.
+         * \return QString of the vector, namely "pos_x, pos_y, dir_x, dir_y, alt0_dir_x, alt0_dir_y, ... , altN_dir_x, altN_dir_y".
+         */
+		void serialize_item(unsigned int index, QXmlStreamWriter& xmlWriter) const;
+        
+        /**
+         * Deserialization/addition of a multi vector from a string to this list.
+         *
+         * \param serial A QString containing the serialization of the vector.
+         * \return True, if the item could be deserialized and the model is not locked.
+         *         The serialization is ordered as: pos_x, pos_y, dir_x, dir_y, alt0_dir_x, alt0_dir_y, ... , altN_dir_x, altN_dir_y
+         */
+		bool deserialize_item(QXmlStreamReader& xmlWriter);
     
     protected slots:
         /**
@@ -725,7 +779,7 @@ class GRAIPE_VECTORFIELDS_EXPORT SparseWeightedMultiVectorfield2D : public Spars
          * \param index Index of the vector to be serialized.
          * \return QString of the vector, namely "pos_x, pos_y, dir_x, dir_y, weight, alt0_dir_x, alt0_dir_y, alt0_weight, ... , altN_dir_x, altN_dir_y, altN_weight".
          */
-		QString serialize_item(unsigned int index) const;
+		QString itemToCSV(unsigned int index) const;
         
         /**
          * Deserialization/addition of a weighted multi vector from a string to this list.
@@ -734,7 +788,25 @@ class GRAIPE_VECTORFIELDS_EXPORT SparseWeightedMultiVectorfield2D : public Spars
          * \return True, if the item could be deserialized and the model is not locked.
          *         The serialization is ordered as: "pos_x, pos_y, dir_x, dir_y, weight, alt0_dir_x, alt0_dir_y, alt0_weight, ... , altN_dir_x, altN_dir_y, altN_weight".
          */
-		bool deserialize_item(const QString& serial);
+		bool itemFromCSV(const QString& serial);
+        
+        /**
+         * Serialization of a single weighted multi vector inside the list at a given index.
+         * The vector will be serialized by means of comma separated values.
+         * 
+         * \param index Index of the vector to be serialized.
+         * \return QString of the vector, namely "pos_x, pos_y, dir_x, dir_y, weight, alt0_dir_x, alt0_dir_y, alt0_weight, ... , altN_dir_x, altN_dir_y, altN_weight".
+         */
+		void serialize_item(unsigned int index, QXmlStreamWriter& xmlWriter) const;
+        
+        /**
+         * Deserialization/addition of a weighted multi vector from a string to this list.
+         *
+         * \param serial A QString containing the serialization of the vector.
+         * \return True, if the item could be deserialized and the model is not locked.
+         *         The serialization is ordered as: "pos_x, pos_y, dir_x, dir_y, weight, alt0_dir_x, alt0_dir_y, alt0_weight, ... , altN_dir_x, altN_dir_y, altN_weight".
+         */
+		bool deserialize_item(QXmlStreamReader& xmlWriter);
    
     protected slots:
         /**

--- a/src/modules/vectorfields/sparsevectorfield.hxx
+++ b/src/modules/vectorfields/sparsevectorfield.hxx
@@ -176,7 +176,7 @@ class GRAIPE_VECTORFIELDS_EXPORT SparseVectorfield2D
          *
          * \param out The output device for serialization.
          */
-		void serialize_content(QIODevice& out) const;
+		void serialize_content(QXmlStreamWriter& xmlWriter) const;
     
         /**
          * Deserializion of a  sparse vectorfield from a QIODevice.

--- a/src/modules/vectorfields/sparsevectorfieldviewcontroller.cxx
+++ b/src/modules/vectorfields/sparsevectorfieldviewcontroller.cxx
@@ -240,7 +240,7 @@ QRectF SparseVectorfield2DViewController::boundingRect () const
  *
  * \return Always: "SparseVectorfield2DViewController"
  */
-QString SparseVectorfield2DViewController::typeName()
+QString SparseVectorfield2DViewController::typeName() const
 { 
 	return "SparseVectorfield2DViewController";
 }
@@ -608,7 +608,7 @@ void SparseWeightedVectorfield2DViewController::paint(QPainter *painter, const Q
  *
  * \return Always: "SparseWeightedVectorfield2DViewController"
  */
-QString SparseWeightedVectorfield2DViewController::typeName()
+QString SparseWeightedVectorfield2DViewController::typeName() const
 { 
 	return "SparseWeightedVectorfield2DViewController"; 
 }
@@ -952,7 +952,7 @@ void SparseMultiVectorfield2DViewController::paint(QPainter *painter, const QSty
  *
  * \return Always: "SparseMultiVectorfield2DViewController"
  */
-QString SparseMultiVectorfield2DViewController::typeName()
+QString SparseMultiVectorfield2DViewController::typeName() const
 { 
 	return "SparseMultiVectorfield2DViewController"; 
 }
@@ -1317,7 +1317,7 @@ void SparseWeightedMultiVectorfield2DViewController::paint(QPainter *painter, co
  *
  * \return Always: "SparseWeightedMultiVectorfield2DViewController"
  */
-QString SparseWeightedMultiVectorfield2DViewController::typeName()
+QString SparseWeightedMultiVectorfield2DViewController::typeName() const
 { 
 	return "SparseWeightedMultiVectorfield2DViewController";
 }

--- a/src/modules/vectorfields/sparsevectorfieldviewcontroller.cxx
+++ b/src/modules/vectorfields/sparsevectorfieldviewcontroller.cxx
@@ -240,7 +240,7 @@ QRectF SparseVectorfield2DViewController::boundingRect () const
  *
  * \return Always: "SparseVectorfield2DViewController"
  */
-QString SparseVectorfield2DViewController::typeName()  const
+QString SparseVectorfield2DViewController::typeName()
 { 
 	return "SparseVectorfield2DViewController";
 }
@@ -608,7 +608,7 @@ void SparseWeightedVectorfield2DViewController::paint(QPainter *painter, const Q
  *
  * \return Always: "SparseWeightedVectorfield2DViewController"
  */
-QString SparseWeightedVectorfield2DViewController::typeName() const
+QString SparseWeightedVectorfield2DViewController::typeName()
 { 
 	return "SparseWeightedVectorfield2DViewController"; 
 }
@@ -952,7 +952,7 @@ void SparseMultiVectorfield2DViewController::paint(QPainter *painter, const QSty
  *
  * \return Always: "SparseMultiVectorfield2DViewController"
  */
-QString SparseMultiVectorfield2DViewController::typeName() const
+QString SparseMultiVectorfield2DViewController::typeName()
 { 
 	return "SparseMultiVectorfield2DViewController"; 
 }
@@ -1317,7 +1317,7 @@ void SparseWeightedMultiVectorfield2DViewController::paint(QPainter *painter, co
  *
  * \return Always: "SparseWeightedMultiVectorfield2DViewController"
  */
-QString SparseWeightedMultiVectorfield2DViewController::typeName() const
+QString SparseWeightedMultiVectorfield2DViewController::typeName()
 { 
 	return "SparseWeightedMultiVectorfield2DViewController";
 }

--- a/src/modules/vectorfields/sparsevectorfieldviewcontroller.cxx
+++ b/src/modules/vectorfields/sparsevectorfieldviewcontroller.cxx
@@ -378,7 +378,7 @@ void SparseVectorfield2DViewController::hoverMoveEvent(QGraphicsSceneHoverEvent 
             }
             else
             {
-                vectors_in_reach =		QString("<table align='center' border='1'><tr> <td>Idx</td> <td>x</td> <td>y</td> <td>length</td> <td>angle</td> <td>dist</td> </tr>")
+                vectors_in_reach =		QString("<table><tr> <th>Idx</th> <th>x</th> <th>y</th> <th>length</th> <th>angle</th> <th>dist</th> </tr>")
                 +	vectors_in_reach
                 +	QString("</table>");
             }
@@ -386,7 +386,7 @@ void SparseVectorfield2DViewController::hoverMoveEvent(QGraphicsSceneHoverEvent 
             emit updateStatusText(vf->shortName() + QString("[%1,%2]").arg(x).arg(y));
             emit updateStatusDescription(	QString("<b>Mouse moved over Object: </b><br/><i>") 
                                          +	vf->shortName()
-                                         +	QString("</i><br/>at position [%1,%2]").arg(x).arg(y)
+                                         +	QString("</i><br/>at position [%1,%2]:<br/>").arg(x).arg(y)
                                          +	vectors_in_reach);
             
             event->accept();
@@ -750,7 +750,7 @@ void SparseWeightedVectorfield2DViewController::hoverMoveEvent(QGraphicsSceneHov
             }
             else
             {
-                vectors_in_reach =		QString("<table align='center' border='1'><tr> <td>Idx</td> <td>x</td> <td>y</td> <td>length</td> <td>angle</td> <td>weight</td> <td>dist</td> </tr>")
+                vectors_in_reach =		QString("<table><tr> <th>Idx</th> <th>x</th> <th>y</th> <th>length</th> <th>angle</th> <th>weight</th> <th>dist</th> </tr>")
                 +	vectors_in_reach
                 +	QString("</table>");
             }
@@ -758,7 +758,7 @@ void SparseWeightedVectorfield2DViewController::hoverMoveEvent(QGraphicsSceneHov
             emit updateStatusText(vf->shortName() + QString("[%1,%2]").arg(x).arg(y));
             emit updateStatusDescription(	QString("<b>Mouse moved over Object: </b><br/><i>") 
                                          +	vf->shortName()
-                                         +	QString("</i><br/>at position [%1,%2]").arg(x).arg(y)
+                                         +	QString("</i><br/>at position [%1,%2]:<br/>").arg(x).arg(y)
                                          +	vectors_in_reach);
             
             event->accept();
@@ -1090,7 +1090,7 @@ void SparseMultiVectorfield2DViewController::hoverMoveEvent(QGraphicsSceneHoverE
             }
             else
             {
-                vectors_in_reach =		QString("<table align='center' border='1'><tr> <td>Idx</td> <td>x</td> <td>y</td> <td>length</td> <td>angle</td> <td>dist</td> </tr>")
+                vectors_in_reach =		QString("<table><tr> <th>Idx</th> <th>x</th> <th>y</th> <th>length</th> <th>angle</th> <th>dist</th> </tr>")
                 +	vectors_in_reach
                 +	QString("</table>");
             }
@@ -1098,7 +1098,7 @@ void SparseMultiVectorfield2DViewController::hoverMoveEvent(QGraphicsSceneHoverE
             emit updateStatusText(vf->shortName() + QString("[%1,%2]").arg(x).arg(y));
             emit updateStatusDescription(	QString("<b>Mouse moved over Object: </b><br/><i>") 
                                          +	vf->shortName()
-                                         +	QString("</i><br/>at position [%1,%2]").arg(x).arg(y)
+                                         +	QString("</i><br/>at position [%1,%2]:<br/>").arg(x).arg(y)
                                          +	vectors_in_reach);
                                          
             event->accept();
@@ -1460,7 +1460,7 @@ void SparseWeightedMultiVectorfield2DViewController::hoverMoveEvent(QGraphicsSce
             }
             else
             {
-                vectors_in_reach =		QString("<table align='center' border='1'><tr> <td>Idx</td> <td>x</td> <td>y</td> <td>length</td> <td>angle</td> <td>weight</td> <td>dist</td> </tr>")
+                vectors_in_reach =		QString("<table><tr> <th>Idx</th> <th>x</th> <th>y</th> <th>length</th> <th>angle</th> <th>weight</th> <th>dist</th> </tr>")
                 +	vectors_in_reach
                 +	QString("</table>");
             }
@@ -1468,7 +1468,7 @@ void SparseWeightedMultiVectorfield2DViewController::hoverMoveEvent(QGraphicsSce
             emit updateStatusText(vf->shortName() + QString("[%1,%2]").arg(x).arg(y));
             emit updateStatusDescription(	QString("<b>Mouse moved over Object: </b><br/><i>") 
                                          +	vf->shortName()
-                                         +	QString("</i><br/>at position [%1,%2]").arg(x).arg(y)
+                                         +	QString("</i><br/>at position [%1,%2]:<br/>").arg(x).arg(y)
                                          +	vectors_in_reach);
             
             event->accept();

--- a/src/modules/vectorfields/sparsevectorfieldviewcontroller.hxx
+++ b/src/modules/vectorfields/sparsevectorfieldviewcontroller.hxx
@@ -91,7 +91,7 @@ class GRAIPE_VECTORFIELDS_EXPORT SparseVectorfield2DViewController
          *
          * \return Always: "SparseVectorfield2DViewController"
          */
-		QString typeName() const;
+		static QString typeName();
     
         /**
          * Specialization of the update of  the parameters of this ViewController according to the current
@@ -189,7 +189,7 @@ class GRAIPE_VECTORFIELDS_EXPORT SparseWeightedVectorfield2DViewController
          *
          * \return Always: "SparseWeightedVectorfield2DViewController"
          */
-		QString typeName() const;
+		static QString typeName();
 	
         /**
          * Specialization of the update of  the parameters of this ViewController according to the current
@@ -276,7 +276,7 @@ class GRAIPE_VECTORFIELDS_EXPORT SparseMultiVectorfield2DViewController
          *
          * \return Always: "SparseMultiVectorfield2DViewController"
          */
-		QString typeName() const;
+		static QString typeName();
 		
 	
         /**
@@ -357,7 +357,7 @@ class GRAIPE_VECTORFIELDS_EXPORT SparseWeightedMultiVectorfield2DViewController
          *
          * \return Always: "SparseWeightedMultiVectorfield2DViewController"
          */
-		QString typeName() const;
+		static QString typeName();
 	
         /**
          * Specialization of the update of  the parameters of this ViewController according to the current

--- a/src/modules/vectorfields/sparsevectorfieldviewcontroller.hxx
+++ b/src/modules/vectorfields/sparsevectorfieldviewcontroller.hxx
@@ -91,7 +91,7 @@ class GRAIPE_VECTORFIELDS_EXPORT SparseVectorfield2DViewController
          *
          * \return Always: "SparseVectorfield2DViewController"
          */
-		static QString typeName();
+		virtual QString typeName() const;
     
         /**
          * Specialization of the update of  the parameters of this ViewController according to the current
@@ -189,7 +189,7 @@ class GRAIPE_VECTORFIELDS_EXPORT SparseWeightedVectorfield2DViewController
          *
          * \return Always: "SparseWeightedVectorfield2DViewController"
          */
-		static QString typeName();
+		virtual QString typeName() const;
 	
         /**
          * Specialization of the update of  the parameters of this ViewController according to the current
@@ -276,7 +276,7 @@ class GRAIPE_VECTORFIELDS_EXPORT SparseMultiVectorfield2DViewController
          *
          * \return Always: "SparseMultiVectorfield2DViewController"
          */
-		static QString typeName();
+		virtual QString typeName() const;
 		
 	
         /**
@@ -357,7 +357,7 @@ class GRAIPE_VECTORFIELDS_EXPORT SparseWeightedMultiVectorfield2DViewController
          *
          * \return Always: "SparseWeightedMultiVectorfield2DViewController"
          */
-		static QString typeName();
+		virtual QString typeName() const;
 	
         /**
          * Specialization of the update of  the parameters of this ViewController according to the current

--- a/src/modules/vectorfields/vectorfield.cxx
+++ b/src/modules/vectorfields/vectorfield.cxx
@@ -67,7 +67,7 @@ Vectorfield2D::Vectorfield2D(const Vectorfield2D & vf)
  *
  * \return Always "Vectorfield2D"
  */
-QString Vectorfield2D::typeName() const
+QString Vectorfield2D::typeName()
 { 
 	return	QString("Vectorfield2D");
 }

--- a/src/modules/vectorfields/vectorfield.cxx
+++ b/src/modules/vectorfields/vectorfield.cxx
@@ -67,7 +67,7 @@ Vectorfield2D::Vectorfield2D(const Vectorfield2D & vf)
  *
  * \return Always "Vectorfield2D"
  */
-QString Vectorfield2D::typeName()
+QString Vectorfield2D::typeName() const
 { 
 	return	QString("Vectorfield2D");
 }

--- a/src/modules/vectorfields/vectorfield.hxx
+++ b/src/modules/vectorfields/vectorfield.hxx
@@ -70,7 +70,7 @@ class GRAIPE_VECTORFIELDS_EXPORT Vectorfield2D
          *
          * \return Always "Vectorfield2D"
          */
-        static QString typeName();
+        virtual QString typeName() const;
     
         /**
          * Getter for the scaling function of the vector length

--- a/src/modules/vectorfields/vectorfield.hxx
+++ b/src/modules/vectorfields/vectorfield.hxx
@@ -70,7 +70,7 @@ class GRAIPE_VECTORFIELDS_EXPORT Vectorfield2D
          *
          * \return Always "Vectorfield2D"
          */
-        QString typeName() const;
+        static QString typeName();
     
         /**
          * Getter for the scaling function of the vector length

--- a/src/modules/winddetection/winddetectionmodule.cxx
+++ b/src/modules/winddetection/winddetectionmodule.cxx
@@ -189,7 +189,7 @@ class FourierSpectrumWindDetector
                                                                                             param_threshold->value(), 
                                                                                             param_radius->value()));
                     
-                    m_results.back()->setName(QString("FFT Wind estimation using ") + param_imageBand->valueText());
+                    m_results.back()->setName(QString("FFT Wind estimation using ") + param_imageBand->toString());
                     
                     QString descr("The following parameters were used to calculate the Fourier Wind field:\n");
                     descr += m_parameters->valueText("ModelParameter");
@@ -357,7 +357,7 @@ class StructureTensorWindDetector
                                                                                 param_innerScale->value(), param_outerScale->value(), 
                                                                                 direction_vectors()[param_wind_knowledge->value()]);
                 
-                    new_wind_vectorfield->setName(QString("ST Wind estimation using ") + param_imageBand->valueText());
+                    new_wind_vectorfield->setName(QString("ST Wind estimation using ") + param_imageBand->toString());
                     
                     QString descr("The following parameters were used to compute ST winds:\n");
                     descr += m_parameters->valueText("ModelParameter");


### PR DESCRIPTION
Now, the XML-Format is used for Model and ViewController de/serialisation. Since this works on an XMLStream, it allows multiple Models and ViewControllers per file and thus simplifies the workspace de/serialisation, too.